### PR TITLE
Updates to Create Input File Page

### DIFF
--- a/rmgweb/media/expandingMenu.js
+++ b/rmgweb/media/expandingMenu.js
@@ -102,9 +102,25 @@ function initMenu2(){
   }
 }
 
+function initMenu3(){
+  var menus, menu, text, a, i;
+  menus = getChildrenByElement(document.getElementById("constraintmenu"));
+  for(i = 0; i < menus.length; i++){
+    menu = menus[i];
+    text = getFirstChildByText(menu);
+    a = document.createElement("a");
+    menu.replaceChild(a, text);
+    a.appendChild(text);
+    a.href = "#";
+    a.onclick = showMenu;
+    a.onfocus = function(){this.blur()};
+  }
+}
+
 function start() {
   initMenu();
   initMenu2();
+  initMenu3();
 }
 
 if(document.createElement) window.onload = start;

--- a/rmgweb/media/expandingMenu.js
+++ b/rmgweb/media/expandingMenu.js
@@ -117,10 +117,27 @@ function initMenu3(){
   }
 }
 
+
+function initMenu4(){
+  var menus, menu, text, a, i;
+  menus = getChildrenByElement(document.getElementById("qmmenu"));
+  for(i = 0; i < menus.length; i++){
+    menu = menus[i];
+    text = getFirstChildByText(menu);
+    a = document.createElement("a");
+    menu.replaceChild(a, text);
+    a.appendChild(text);
+    a.href = "#";
+    a.onclick = showMenu;
+    a.onfocus = function(){this.blur()};
+  }
+}
+
 function start() {
   initMenu();
   initMenu2();
   initMenu3();
+  initMenu4();
 }
 
 if(document.createElement) window.onload = start;

--- a/rmgweb/rmg/forms.py
+++ b/rmgweb/rmg/forms.py
@@ -119,6 +119,7 @@ class InputForm(forms.ModelForm):
             'maximumSulfurAtoms':forms.TextInput(attrs={'size':'2'}),
             'maximumHeavyAtoms':forms.TextInput(attrs={'size':'2'}),
             'maximumRadicalElectrons':forms.TextInput(attrs={'size':'2'}),
+            'maxRadicalNumber':forms.TextInput(attrs={'size':'2'}),
         }
 
 

--- a/rmgweb/rmg/forms.py
+++ b/rmgweb/rmg/forms.py
@@ -134,8 +134,8 @@ class ReactorSpeciesForm(forms.ModelForm):
     class Meta:
         model = ReactorSpecies
         widgets ={
-        'name': forms.TextInput(attrs={'style':'width:100%;'}),
-        'identifier': forms.TextInput(attrs={'onchange':'resolve(this.id);','class':'identifier', 'style':'width:100%;'}),
+        'name': forms.TextInput(),
+        'identifier': forms.TextInput(attrs={'onchange':'resolve(this.id);','class':'identifier'}),
         'adjlist':forms.Textarea(attrs={'cols': 50, 'rows': 10 }),
         'molefrac': forms.TextInput(attrs={'size':'5'}),
         }

--- a/rmgweb/rmg/forms.py
+++ b/rmgweb/rmg/forms.py
@@ -110,8 +110,16 @@ class InputForm(forms.ModelForm):
             'maximumEdgeSpecies' : forms.TextInput(attrs={'size':'5'}),
             'simulator_atol' : forms.TextInput(attrs={'size':'3'}),
             'simulator_rtol': forms.TextInput(attrs={'size':'3'}),
-            'saveRestartPeriod':forms.TextInput(attrs={'size':5}),
-        }  
+            'saveRestartPeriod':forms.TextInput(attrs={'size':'5'}),
+            'maximumCarbonAtoms':forms.TextInput(attrs={'size':'2'}),
+            'maximumHydrogenAtoms':forms.TextInput(attrs={'size':'2'}),
+            'maximumOxygenAtoms':forms.TextInput(attrs={'size':'2'}),
+            'maximumNitrogenAtoms':forms.TextInput(attrs={'size':'2'}),
+            'maximumSiliconAtoms':forms.TextInput(attrs={'size':'2'}),
+            'maximumSulfurAtoms':forms.TextInput(attrs={'size':'2'}),
+            'maximumHeavyAtoms':forms.TextInput(attrs={'size':'2'}),
+            'maximumRadicalElectrons':forms.TextInput(attrs={'size':'2'}),
+        }
 
 
 class ThermoLibraryForm(forms.ModelForm):

--- a/rmgweb/rmg/models.py
+++ b/rmgweb/rmg/models.py
@@ -481,6 +481,7 @@ class Input(models.Model):
     grain_units = (('kcal/mol','kcal/mol',),('kJ/mol','kJ/mol',))
     grainsize_units = models.CharField(max_length = 50, default = 'kcal/mol', choices = grain_units)
     minimumNumberOfGrains = models.PositiveIntegerField(blank = True, default = 200, null = True)
+    maximumAtoms = models.PositiveIntegerField(blank = True, null = True)
     # P and T Range
     p_low = models.FloatField(blank = True, null = True)
     p_high = models.FloatField(blank = True, null = True)
@@ -668,6 +669,8 @@ class Input(models.Model):
             initial['maximumGrainSize'] = self.rmg.pressureDependence.maximumGrainSize.getValue()
             initial['grainsize_units'] = self.rmg.pressureDependence.maximumGrainSize.units
             initial['minimumNumberOfGrains'] = self.rmg.pressureDependence.minimumGrainCount
+            
+            initial['maximumAtoms'] = self.rmg.pressureDependence.maximumAtoms
         else:
             initial['pdep'] = 'off'    
             
@@ -807,7 +810,7 @@ class Input(models.Model):
             self.rmg.pressureDependence.grainSize = Quantity(form.cleaned_data['maximumGrainSize'], form.cleaned_data['grainsize_units'].encode())
             self.rmg.pressureDependence.grainCount = form.cleaned_data['minimumNumberOfGrains']
             
-        
+            self.rmg.pressureDependence.maximumAtoms = form.cleaned_data['maximumAtoms']
         # Additional Options
         self.rmg.units = 'si' 
         self.rmg.saveRestartPeriod = Quantity(form.cleaned_data['saveRestartPeriod'], form.cleaned_data['saveRestartPeriodUnits'].encode()) if form.cleaned_data['saveRestartPeriod'] else None

--- a/rmgweb/rmg/models.py
+++ b/rmgweb/rmg/models.py
@@ -761,10 +761,9 @@ class Input(models.Model):
             # Sensitivity Analysis
             sensitiveSpecies = []
             if item.sensitivity:
-                if isinstance(item.sensitivity.encode(), str): sensitivity = item.sensitivity.encode().split(',')
+                if isinstance(item.sensitivity.encode(), str): sensitivity = item.sensitivity.encode().split(',').strip()
                 for spec in sensitivity:
                     sensitiveSpecies.append(speciesDict[spec])
-            print sensitiveSpecies
             system = SimpleReactor(T, P, initialMoleFractions, termination, sensitiveSpecies, item.sensitivityThreshold)
             self.rmg.reactionSystems.append(system)
     

--- a/rmgweb/rmg/models.py
+++ b/rmgweb/rmg/models.py
@@ -513,9 +513,9 @@ class Input(models.Model):
     method_options = (('pm3','pm3',),('pm6','pm6',),('pm7','pm7 (MOPAC2012 only)',))
     method = models.CharField(max_length = 50, default = 'off', choices = method_options)
     fileStore = models.CharField(max_length = 100, default = 'QMfiles', blank = True)
-    scratchDirectory = models.CharField(max_length = 100, blank = True)
-    onlyCyclics = models.BooleanField()
-    maxRadicalNumber = models.PositiveSmallIntegerField(blank = True, null = True)
+    scratchDirectory = models.CharField(max_length = 100, default = 'QMscratch', blank = True)
+    onlyCyclics = models.BooleanField(default=True)
+    maxRadicalNumber = models.PositiveSmallIntegerField(blank = True, default=0)
     
     # Generated Species Constraints
     speciesConstraints = models.CharField(max_length = 50, default = 'off', choices = on_off)

--- a/rmgweb/rmg/models.py
+++ b/rmgweb/rmg/models.py
@@ -504,6 +504,8 @@ class Input(models.Model):
     maximumEdgeSpecies = models.PositiveIntegerField(default = 100000)
     simulator_atol = models.FloatField(default = 1e-16)
     simulator_rtol = models.FloatField(default = 1e-8)
+    simulator_sens_atol = models.FloatField(default = 1e-6)
+    simulator_sens_rtol = models.FloatField(default = 1e-4)
     
     # Quantum Calculations
     on_off = (('off','off',),('on','on',))
@@ -637,6 +639,8 @@ class Input(models.Model):
         initial = {}
         initial['simulator_atol'] = self.rmg.absoluteTolerance 
         initial['simulator_rtol'] = self.rmg.relativeTolerance 
+        initial['simulator_sens_atol'] = self.rmg.sensitivityAbsoluteTolerance 
+        initial['simulator_sens_rtol'] = self.rmg.sensitivityRelativeTolerance 
         initial['toleranceKeepInEdge'] = self.rmg.fluxToleranceKeepInEdge 
         initial['toleranceMoveToCore']= self.rmg.fluxToleranceMoveToCore
         initial['toleranceInterruptSimulation'] = self.rmg.fluxToleranceInterrupt
@@ -770,6 +774,8 @@ class Input(models.Model):
         # Simulator tolerances
         self.rmg.absoluteTolerance = form.cleaned_data['simulator_atol']
         self.rmg.relativeTolerance = form.cleaned_data['simulator_rtol']
+        self.rmg.sensitivityAbsoluteTolerance = form.cleaned_data['simulator_sens_atol']
+        self.rmg.sensitivityRelativeTolerance = form.cleaned_data['simulator_sens_rtol']
         self.rmg.fluxToleranceKeepInEdge = form.cleaned_data['toleranceKeepInEdge']
         self.rmg.fluxToleranceMoveToCore = form.cleaned_data['toleranceMoveToCore']
         self.rmg.fluxToleranceInterrupt = form.cleaned_data['toleranceInterruptSimulation']

--- a/rmgweb/rmg/models.py
+++ b/rmgweb/rmg/models.py
@@ -651,7 +651,7 @@ class Input(models.Model):
             # Pressure dependence method
             initial['pdep'] = self.rmg.pressureDependence.method.lower()
             # Process interpolation model
-            initial['interpolation'] = self.rmg.pressureDependence.interpolationModel[0]
+            initial['interpolation'] = self.rmg.pressureDependence.interpolationModel[0].lower()
             if initial['interpolation'] == 'chebyshev':
                 initial['temp_basis'] = self.rmg.pressureDependence.interpolationModel[1]
                 initial['p_basis'] = self.rmg.pressureDependence.interpolationModel[2]

--- a/rmgweb/rmg/models.py
+++ b/rmgweb/rmg/models.py
@@ -521,9 +521,9 @@ class Input(models.Model):
     
     # Generated Species Constraints
     speciesConstraints = models.CharField(max_length = 50, default = 'off', choices = on_off)
-    allowed_inputSpecies = models.BooleanField(default = True)
-    allowed_seedMechanisms = models.BooleanField(default = True)
-    allowed_reactionLibraries = models.BooleanField(default = True)
+    allowed_inputSpecies = models.BooleanField(default = False)
+    allowed_seedMechanisms = models.BooleanField(default = False)
+    allowed_reactionLibraries = models.BooleanField(default = False)
     maximumCarbonAtoms = models.PositiveSmallIntegerField(blank = True, null = True)
     maximumHydrogenAtoms = models.PositiveSmallIntegerField(blank = True, null = True)
     maximumOxygenAtoms = models.PositiveSmallIntegerField(blank = True, null = True)

--- a/rmgweb/rmg/models.py
+++ b/rmgweb/rmg/models.py
@@ -497,7 +497,7 @@ class Input(models.Model):
     p_basis = models.PositiveIntegerField(blank = True, default = 4, null = True)
 
     # Tolerance
-    toleranceMoveToCore = models.FloatField(blank=True, null=True)
+    toleranceMoveToCore = models.FloatField(default = 0.1)
     toleranceKeepInEdge= models.FloatField(default = 0.0)
     # Tolerance Advanced Options
     toleranceInterruptSimulation = models.FloatField(default = 1.0)
@@ -585,7 +585,7 @@ class Input(models.Model):
         
         initial_reaction_libraries = []
         if self.rmg.seedMechanisms:
-            for item in self.rmg.seedMechanism:
+            for item in self.rmg.seedMechanisms:
                 initial_reaction_libraries.append({'reactionlib': item, 'seedmech': True, 'edge': False})
         if self.rmg.reactionLibraries:
             for item, edge in self.rmg.reactionLibraries:
@@ -722,8 +722,8 @@ class Input(models.Model):
                 else:
                     self.rmg.seedMechanisms.append(item.reactionlib.encode())
         self.rmg.statmechLibraries = []
-        self.rmg.kineticsDepositories = ['training']
-        self.rmg.kineticsFamilies = ['!Intra_Disproportionation']        
+        self.rmg.kineticsDepositories = 'default'
+        self.rmg.kineticsFamilies = 'default'
         self.rmg.kineticsEstimator = 'rate rules'
         
         # Species

--- a/rmgweb/rmg/models.py
+++ b/rmgweb/rmg/models.py
@@ -678,7 +678,16 @@ class Input(models.Model):
         if self.rmg.speciesConstraints:
             initial['speciesConstraints'] = 'on'
             for key, value in self.rmg.speciesConstraints.items():
-                initial[key] = value
+                if key == 'allowed':
+                    allowed_dict = {'input species':'allowed_inputSpecies', 'reaction libraries':'allowed_reactionLibraries', 'seed mechanisms':'allowed_seedMechanisms'}
+                    if isinstance(value,list):
+                        for allowed_name in value:
+                            field = allowed_dict[allowed_name.lower()]
+                            initial[field] = True
+                    else:
+                        raise Exception("Input File generatedSpeciesConstraints(allowed='[..]'), allowed block must be a list containing either 'reaction libraries', 'seed mechanisms', or 'input species'." )
+                else:
+                    initial[key] = value
         else:
             initial['speciesConstraints'] = 'off'
         

--- a/rmgweb/rmg/templates/input.html
+++ b/rmgweb/rmg/templates/input.html
@@ -368,7 +368,7 @@ If you already have a saved input.py file that you would like to modify, you can
     <p>
     RMG is also able to perform sensitivity analysis, provided it was compiled with the DASPK solver.
     To enable sensitivity analysis, provide the species that the analysis should be done for.
-    Multiple species should be comma separated, without spaces.
+    Multiple species should be comma separated.
     The sensitivity threshold is the minimum sensitivity to be saved to the output file.
 </ol>
 

--- a/rmgweb/rmg/templates/input.html
+++ b/rmgweb/rmg/templates/input.html
@@ -232,7 +232,8 @@ blockquote {
 
 {% block page_body %}
 
-This form will generate an input file for a RMG-Py job.
+This form will generate an input file for a RMG-Py job. For more detailed explanations of each option, 
+please see the <a href="http://reactionmechanismgenerator.github.io/RMG-Py/users/rmg/input.html" target="_blank">documentation</a>.
 <P>
 
 <hr/>
@@ -294,9 +295,9 @@ If you already have a saved input.py file that you would like to modify, you can
     <P>
     Normally, the kinetic library of reactions is used to estimate a reaction found on the edge.
     However, if you believe the reactions should be included within the mechanism core, select the
-    "SeedMech" option to allow to the library to be added to the core.
+    "SeedMech" option to force the entire library to be added to the core.
     If you do not wish for these reactions to be automatically included in the core but do want to
-    retain it in your mechanism, you may also select the "Edge" option.
+    retain it in your mechanism, you may select the "Edge" option instead.
     <P>
     You can browse the available libraries here: <a href="{% url 'database.views.kinetics' section='libraries' %}" target="_blank">Kinetics Libraries</a>
     <P>
@@ -322,10 +323,10 @@ If you already have a saved input.py file that you would like to modify, you can
 
     <li><h3>Reactor Species:</h3>
     
-    Use this form to add a species to the RMG job from its adjacency list.  The "name" field will be used throughout your mechanism to identify this species.
+    Use this form to add a species to the RMG job using its adjacency list. The "name" field will be used throughout your mechanism to identify this species.
     You can quickly fill in the adjacency list part of the form by entering any species identifier,
-    such as a SMILES, InChI, CAS number, or species name in the 'species identifier' field and pressing tab.
-    This is translated into an adjacency list using the <a href="http://cactus.nci.nih.gov/chemical/structure">NCI Chemical Identifier Resolver</a>.
+    such as a SMILES, InChI, CAS number, or species name in the "species identifier" field and pressing tab.
+    This is translated into an adjacency list using the <a href="http://cactus.nci.nih.gov/chemical/structure" target="_blank">NCI Chemical Identifier Resolver</a>.
     
 </ol>
     
@@ -353,11 +354,16 @@ If you already have a saved input.py file that you would like to modify, you can
     <p>
     Enter individual reactor system settings for which the RMG model will be valid.
     You may add multiple reactor systems for which the overall mechanism will be valid.
-    <P>
+    <p>
     You must provide a maximum reaction time for the job.
-    A species conversion requirement is optional- be sure to use the 
-    same species name as provided previously.  The RMG job will stop as soon as
+    A species conversion requirement is optional - be sure to use the 
+    same species name as provided previously. The RMG job will stop as soon as
     one of the termination criteria is fulfilled.
+    <p>
+    RMG is also able to perform sensitivity analysis, provided it was compiled with the DASPK solver.
+    To enable sensitivity analysis, provide the species that the analysis should be done for.
+    Multiple species should be comma separated, without spaces.
+    The sensitivity threshold is the minimum sensitivity to be saved to the output file.
 </ol>
 
 <ul class="form">
@@ -386,10 +392,40 @@ If you already have a saved input.py file that you would like to modify, you can
 </ul>
 
 <ol>
-    <li value="5"><h3>Pressure Dependence: {{ form.pdep }}</h3>
+    <li value="5"><h3>Tolerances</h3>
+    
+    <P>Indicate your allowed flux tolerance for moving a reaction from the edge to the core.
+    In advanced options, you can set additional tolerances for the solver, and 
+    for the edge reactions (the possible reactions generated from the species in the core).
+    Generally, the edge tolerance is set to zero unless you need to prune the edge to reduce 
+    model generation time and memory consumption. For more information on pruning, please see the 
+    <a href="http://reactionmechanismgenerator.github.io/RMG-Py/users/rmg/input.html#pruning" target="_blank">documentation</a>.
+    
+    <P><table><tr><th>Core Tolerance:</th><td> {{ form.toleranceMoveToCore }}</td></tr></table>
+</ol>
+
+<ul id="tolmenu"><li>Advanced Options
+    <ol><li>
+        <table>
+            <tr><th>Edge Tolerance:</th>                          <td>{{ form.toleranceKeepInEdge }}</td></tr>
+            <tr><th>Tolerance to Interrupt Simulation:</th>       <td>{{form.toleranceInterruptSimulation}}</td></tr>
+            <tr><th>Maximum Number of Allowed Edge Species:</th>  <td>{{form.maximumEdgeSpecies}}</td></tr></table>
+            <P><i>Numerical Solver</i>
+                <br><table>
+                <tr><th>Absolute Tolerance: </th>    <td>{{ form.simulator_atol }}</td></tr>
+                <tr><th>Relative Tolerance: </th>    <td>{{ form.simulator_rtol }}</td></tr>
+        </table>
+    </li></ol>
+</li></ul>
+
+<P><br>
+
+<ol>
+    <li value="6"><h3>Pressure Dependence: {{ form.pdep }}</h3>
     <P>
-    If you would like to generate a pressure-dependent model, please select the form of interpolation as well as the pressure dependent 
-    reaction format (Chebyshev or Pdep Arrhenius) you would like RMG to output.
+    If you would like to generate a pressure-dependent model, please select the pressure dependence method (above) as well as the interpolation model
+    (Chebyshev or Pdep Arrhenius) you would like RMG to use. See advanced options to set the number of interpolation points, 
+    grain size, or number of basis function for Chebyshev interpolation.
     <P>
     
     <table>
@@ -418,37 +454,10 @@ If you already have a saved input.py file that you would like to modify, you can
 <P><br>
 
 <ol>
-    <li value="6"><h3>Tolerances</h3>
-    
-    <P>Indicate your allowed flux tolerance for moving a reaction to the core or keeping
-    the reaction on the edge.  In the advanced options, you can set additional tolerances for the solver, and 
-    for the edge reactions (the possible reactions generated from the species in the core).
-    Generally, the edge tolerance is set to zero unless you need to prune the edge to reduce 
-    model generation time.
-    
-    <P><table><tr><th>Core Tolerance:</th><td> {{ form.toleranceMoveToCore }}</td></tr></table>
-</ol>
-
-<ul id="tolmenu"><li>Advanced Options
-    <ol><li>
-        <table>
-            <tr><th>Edge Tolerance:</th>                          <td>{{ form.toleranceKeepInEdge }}</td></tr>
-            <tr><th>Tolerance to Interrupt Simulation:</th>       <td>{{form.toleranceInterruptSimulation}}</td></tr>
-            <tr><th>Maximum Number of Allowed Edge Species:</th>  <td>{{form.maximumEdgeSpecies}}</td></tr></table>
-            <P><i>Numerical Solver</i>
-                <br><table>
-                <tr><th>Absolute Tolerance: </th>    <td>{{ form.simulator_atol }}</td></tr>
-                <tr><th>Relative Tolerance: </th>    <td>{{ form.simulator_rtol }}</td></tr>
-        </table>
-    </li></ol>
-</li></ul>
-
-<P><br>
-    
-<ol>
     <li value="7"><h3>Quantum Calculations {{ form.quantumCalc }}</h3>
     
     Optional block for performing on the fly quantum mechanical calculations to determine thermodynamic parameters.
+    Calculations are only performed for molecules not present in the specified thermo libraries.
     
     <P><table>
         <tr><th>Software:</th>                  <td>{{ form.software }}</td></tr>
@@ -464,7 +473,10 @@ If you already have a saved input.py file that you would like to modify, you can
 <ol>
     <li value="8"><h3>Generated Species Constraints {{ form.speciesConstraints }}</h3>
     
-    Optional constraints on allowed species.
+    Optional constraints on allowed species. Species exceeding these constrainted will not be included in the model.
+    In advanced options, allowing input species, seed mechanisms, or reaction libraries lets them bypass these constraints.
+    For more information regarding singlet O2, please see 
+    <a href="http://reactionmechanismgenerator.github.io/RMG-Py/users/rmg/species.html#representing-oxygen" target="_blank">Representing Oxygen</a>.
     
     <P><table>
         <tr><th>Maximum Carbon Atoms:</th>        <td>{{ form.maximumCarbonAtoms }}</td></tr>
@@ -496,8 +508,10 @@ If you already have a saved input.py file that you would like to modify, you can
     <li value="9"><h3>Additional Options</h3>
     
     Restart files can be generated automatically during the progress of a RMG-Py job in order to pick up a job in the middle
-    of a run rather than starting completely from scratch if there is a failure or memory issue.              
-    The save restart period may be optionally left empty if no restart files are desired.  
+    of a run rather than starting completely from scratch if there is a failure or memory issue.
+    The save restart period may be optionally left empty if no restart files are desired.
+    Note that saving restart files for large models can take a significant amount of time, so use caution when selecting the restart period.
+    Explanations for the other options can be found <a href="http://reactionmechanismgenerator.github.io/RMG-Py/users/rmg/input.html#miscellaneous-options" target="_blank">here</a>.
 
     <P><table>
         <tr><th>Save Restart:</th>                 <td>{{ form.saveRestartPeriod }}{{ form.saveRestartPeriodUnits }}</td></tr>

--- a/rmgweb/rmg/templates/input.html
+++ b/rmgweb/rmg/templates/input.html
@@ -444,7 +444,10 @@ If you already have a saved input.py file that you would like to modify, you can
 </ol>
 
 <ul id="pdepmenu"><li>Advanced Options
-    <ol><li>
+    <ol><li><P><i>Maximum Atoms of Isomers in Network</i>
+        <table><tr><th>Maximum Atoms:</th><td> {{ form.maximumAtoms}}</td></tr>
+        <tr><td colspan=2>If used, the number of maximum atoms turns off pressure dependence for molecules with atoms greater than the number specified.
+ 	This is due to faster internal rate of energy transfer for larger molecules. </td></tr> </table>
         <P><i>Number of Interpolation Points Used in Model</i>
             <br><table><tr><th>Temperature:</th><td> {{ form.temp_interp}}</td></tr>
             <tr><th>Pressure:</th><td> {{form.p_interp}}</td></tr></table>

--- a/rmgweb/rmg/templates/input.html
+++ b/rmgweb/rmg/templates/input.html
@@ -139,11 +139,11 @@ ol li {
 }
 
 ul {
-		list-style: none;
-		margin-left: 50px;
-		padding: 0;
-		border: none;
-		}
+        list-style: none;
+        margin-left: 50px;
+        padding: 0;
+        border: none;
+        }
 
  ul#pdepmenu ol {
   display: none;
@@ -229,233 +229,239 @@ If you already have a saved input.py file that you would like to modify, you can
 
     <li><h3>Thermodynamics Libraries</h3>
 
-    Select the thermochemistry libraries you would like to be included
+    Select the thermochemistry libraries you would like to be included 
     in your RMG job in order of priority. You may select multiple libraries.
-    If no libraries are selected, RMG will estimate all species'
-    thermochemistry through Benson group additivity.  We recommend using at least the 'primaryThermoLibrary'. 
+    If no libraries are selected, RMG will estimate all species' thermochemistry through 
+    Benson group additivity. We recommend using at least the 'primaryThermoLibrary'.
+    
     <P>You can browse the available libraries here: <a href="{% url 'database.views.thermo' section='libraries' %}" target="_blank">Thermodynamics Libraries</a>
     <P>
     <table id="thermo_libraries">
-                <thead><tr><th scope="col">Library</th></tr></thead>
-                <tbody>                    
-                    {% for form in thermolibformset.forms %}
-                    <tr id="{{ form.prefix }}-row">          
-                        <td>
-                            {% for fld in form.hidden_fields %}{{ fld }}{% endfor %}
-                            {% if form.instance.pk %}{{ form.DELETE }}{% endif %}
-                            {{ form.thermolib }}
-                        </td>                
-                    </tr>
-                    {% endfor %}
+        <thead><tr><th scope="col">Library</th></tr></thead>
+        <tbody>                    
+            {% for form in thermolibformset.forms %}
+            <tr id="{{ form.prefix }}-row">          
+                <td>
+                {% for fld in form.hidden_fields %}{{ fld }}{% endfor %}
+                {% if form.instance.pk %}{{ form.DELETE }}{% endif %}
+                {{ form.thermolib }}
+                </td>                
+            </tr>
+            {% endfor %}
             {{ thermolibformset.management_form }}
-    </tbody></table>
+        </tbody>
+    </table>
 
     <li><h3>Reaction Libraries</h3>
-Select reaction libraries you would like to be included in your RMG job in order of priority.  Rates from reactions within the library will be used
-if the reaction is found in your job.  You may select multiple libraries.
-If no libraries are selected, RMG will estimate kinetic rates using RMG-database rate rules alone.
-<P>
-Normally, the kinetic library of reactions is used to estimate a reaction found on the edge.
+    
+    Select reaction libraries you would like to be included in your RMG job in order of priority. Rates from reactions within the library will be used 
+    if the reaction is found in your job. You may select multiple libraries.
+    If no libraries are selected, RMG will estimate kinetic rates using RMG-database rate rules alone.
+    <P>
+    Normally, the kinetic library of reactions is used to estimate a reaction found on the edge.
     However, if you believe the reactions should be included within the mechanism core, select the
     "SeedMech" option to allow to the library to be added to the core.
     If you do not wish for these reactions to be automatically included in the core but do want to
     retain it in your mechanism, you may also select the "Edge" option.
-<P>You can browse the available libraries here: <a href="{% url 'database.views.kinetics' section='libraries' %}" target="_blank">Kinetics Libraries</a>
     <P>
-<table id="reaction_libraries">
-                <thead><tr><th scope="col">Library</th>
-                        <th scope="col">SeedMech</th>
-                        <th scope="col">Edge</th></tr></thead>
-                <tbody>
-                    {% for form in reactionlibformset.forms %}
-                    <tr id="{{ form.prefix }}-row">
-                        <td>
-                            {% for fld in form.hidden_fields %}{{ fld }}{% endfor %}
-                            {% if form.instance.pk %}{{ form.DELETE }}{% endif %}
-                            {{ form.reactionlib }} </td>
-                        <td align="center">{{ form.seedmech }}</td>
-                        <td align="center">{{ form.edge }}</td>
-                    </tr>
-                    {% endfor %}
+    You can browse the available libraries here: <a href="{% url 'database.views.kinetics' section='libraries' %}" target="_blank">Kinetics Libraries</a>
+    <P>
+    <table id="reaction_libraries">
+        <thead><tr><th scope="col">Library</th>
+            <th scope="col">SeedMech</th>
+            <th scope="col">Edge</th></tr></thead>
+        <tbody>
+            {% for form in reactionlibformset.forms %}
+            <tr id="{{ form.prefix }}-row">
+                <td>
+                {% for fld in form.hidden_fields %}{{ fld }}{% endfor %}
+                {% if form.instance.pk %}{{ form.DELETE }}{% endif %}
+                {{ form.reactionlib }} </td>
+                <td align="center">{{ form.seedmech }}</td>
+                <td align="center">{{ form.edge }}</td>
+            </tr>
+             {% endfor %}
             {{ reactionlibformset.management_form }}
-</tbody></table>
+        </tbody>
+    </table>
 
 
-<li><h3>Reactor Species:</h3>
-Use this form to add a species to the RMG job from its adjacency list.  The "name" field will be used throughout your mechanism to identify this species.
-You can quickly fill in the adjacency list part of the form by entering any species identifier,
-such as a SMILES, InChI, CAS number</a>, or
-species name in the 'species identifier' field and pressing tab.
-This is translated into an adjacency list using the <a href="http://cactus.nci.nih.gov/chemical/structure">NCI Chemical Identifier Resolver</a>.
-<P>
+    <li><h3>Reactor Species:</h3>
+    
+    Use this form to add a species to the RMG job from its adjacency list.  The "name" field will be used throughout your mechanism to identify this species.
+    You can quickly fill in the adjacency list part of the form by entering any species identifier,
+    such as a SMILES, InChI, CAS number, or species name in the 'species identifier' field and pressing tab.
+    This is translated into an adjacency list using the <a href="http://cactus.nci.nih.gov/chemical/structure">NCI Chemical Identifier Resolver</a>.
+    <P>
+    
 </ol>
-     <ol start="1">
-<table id="reactor_species" border="1" cellpadding ="3" cellspacing ="30" rules="rows">
-    <tbody>{% for form in reactorspecformset.forms %}
-   
-    <tr id="{{ form.prefix }}-row"><td><li>
-        <b>Species Name:</b> {% for fld in form.hidden_fields %}{{ fld }}{% endfor %}
-                            {% if form.instance.pk %}{{ form.DELETE }}{% endif %}
-                            {{ form.name }}
-       <br><b>Species Identifier:</b> {{ form.identifier }}
-       <br><b>Adjacency List:</b>
-       <br>{{ form.adjlist }}
-       <br><b>Mole Fraction:</b> {{form.molefrac}}
-       <br><b>Inert Species:</b> {{ form.inert }}
-    </td><br>
-</tr>
-    {% endfor %}
- {{ reactorspecformset.management_form }}
-                </tbody>
-</table>
-
-     </ol>
-
+    
+<ol start="1">
+    <table id="reactor_species" border="1" cellpadding ="3" cellspacing ="30" rules="rows">
+        <tbody>{% for form in reactorspecformset.forms %}
+            <tr id="{{ form.prefix }}-row"><td><li>
+                <b>Species Name:</b> {% for fld in form.hidden_fields %}{{ fld }}{% endfor %}
+                                     {% if form.instance.pk %}{{ form.DELETE }}{% endif %}
+                                     {{ form.name }}
+                <br><b>Species Identifier:</b> {{ form.identifier }}
+                <br><b>Adjacency List:</b>
+                <br>{{ form.adjlist }}
+                <br><b>Mole Fraction:</b> {{form.molefrac}}
+                <br><b>Inert Species:</b> {{ form.inert }}
+            </td><br>
+            </tr>
+            {% endfor %}
+            {{ reactorspecformset.management_form }}
+        </tbody>
+    </table>
+</ol>
 
 <ol>
- <li value="4"><h3>Reactor Systems</h3>
-            <p>Enter individual reactor system settings for which the RMG model will be valid.
-                You may add multiple reactor systems for which the overall mechanism will be valid.
+    <li value="4"><h3>Reactor Systems</h3>
+    <p>
+    Enter individual reactor system settings for which the RMG model will be valid.
+    You may add multiple reactor systems for which the overall mechanism will be valid.
+    <P>
+    You must provide a maximum reaction time for the job.
+    A species conversion requirement is optional- be sure to use the 
+    same species name as provided previously.  The RMG job will stop as soon as
+    one of the termination criteria is fulfilled.
+</ol>
 
-            <P>You must provide a maximum reaction time for the job.
-            A species conversion requirement is optional- be sure to use the 
-            same species name as provided previously.  The RMG job will stop as soon as
-                one of the termination criteria is fulfilled.</ol>
+<ol start="1">
+    <table id="reactor_systems" border="1" cellpadding ="3" cellspacing ="30" rules="rows">
+        <tbody>{% for form in reactorformset.forms %}
+            <tr id="{{ form.prefix }}-row"><td><li> {% for fld in form.hidden_fields %}{{ fld }}{% endfor %}
+                {% if form.instance.pk %}{{ form.DELETE }}{% endif %}
+            <b>Temperature:</b> {{ form.temperature }} {{ form.temperature_units }}
+            <br><b>Pressure:</b> {{ form.pressure }} {{ form.pressure_units }}    
+            <P><b>Termination Criteria:</b>
+            <blockquote>
+                <b>End Time:</b> {{ form.terminationtime }} {{ form.time_units }}
+                <br><b>Species:</b> {{ form.species }} <b>Conversion:</b> {{ form.conversion }}
+            </blockquote>
+            </td></tr>
+            {% endfor %}
+            {{ reactorformset.management_form }}
+        </tbody>
+    </table>
+</ol>
 
-    <ol start="1">
+<ol>
+    <li value="5"><h3>Pressure Dependence: {{ form.pdep }}</h3>
+    <P>
+    If you would like to generate a pressure-dependent model, please select the form of interpolation as well as the pressure dependent 
+    reaction format (Chebyshev or Pdep Arrhenius) you would like RMG to output.
+    <P>
+    
+    <table>
+        <tr><th colspan="2">Model: {{form.interpolation}}</th></tr>
+        <tr><th>Temperature Range:</th><td> {{form.temp_low}} to {{form.temp_high}} {{form.temprange_high}} {{form.temprange_units}}</td></tr>
+        <tr><th>Pressure Range:</th><td>{{ form.p_low }} to {{form.p_high}} {{form.prange_units}}</td></tr>
+    </table>
+</ol>
 
-        <table id="reactor_systems" border="1" cellpadding ="3" cellspacing ="30" rules="rows">
-    <tbody>{% for form in reactorformset.forms %}
+<ul id="pdepmenu"><li>[x] Advanced Options
+    <ol><li>
+        <P><i>Number of Interpolation Points Used in Model</i>
+            <br><table><tr><th>Temperature:</th><td> {{ form.temp_interp}}</td></tr>
+            <tr><th>Pressure:</th><td> {{form.p_interp}}</td></tr></table>
 
-        <tr id="{{ form.prefix }}-row"><td><li> {% for fld in form.hidden_fields %}{{ fld }}{% endfor %}
-                            {% if form.instance.pk %}{{ form.DELETE }}{% endif %}
-                           
-        <b>Temperature:</b> {{ form.temperature }} {{ form.temperature_units }}
-    <br><b>Pressure:</b> {{ form.pressure }} {{ form.pressure_units }}    
-    <P><b>Termination Criteria:</b>
-    <blockquote>
-            <b>End Time:</b> {{ form.terminationtime }} {{ form.time_units }}
-            <br><b>Species:</b> {{ form.species }} <b>Conversion:</b> {{ form.conversion }}
-    </blockquote>
-                </td></tr>
-    {% endfor %}
- {{ reactorformset.management_form }}
-                                </tbody>
-</table>
-
-     </ol>
-   
-   <ol>
-        <li value="5"><h3>Pressure Dependence: {{ form.pdep }}</h3>
-            <P>
-            If you would like to generate a pressure-dependent model, please select the form of interpolation as well as the pressure dependent 
-			reaction format (Chebyshev or Pdep Arrhenius) you would like RMG to output.
-            <P>
-            
-            <table>
-                <tr><th colspan="2">Model: {{form.interpolation}}</th></tr>
-                <tr><th>Temperature Range:</th><td> {{form.temp_low}} to {{form.temp_high}} {{form.temprange_high}} {{form.temprange_units}}</td></tr>
-                <tr><th>Pressure Range:</th><td>{{ form.p_low }} to {{form.p_high}} {{form.prange_units}}</td></tr>
-            </table>
-
-    </ol>
-            <ul id="pdepmenu"><li>[x] Advanced Options
-   
-                    <ol> <li>
-          
-            <P><i>Number of Interpolation Points Used in Model</i>
-                <br><table><tr><th>Temperature:</th><td> {{ form.temp_interp}}</td></tr>
-                    <tr><th>Pressure:</th><td> {{form.p_interp}}</td></tr></table>
-
-            <P><i>Grain Size</i>
+        <P><i>Grain Size</i>
             <br><table><tr><th>Maximum Size:</th><td> {{form.maximumGrainSize}} {{form.grainsize_units}}</td></tr>
-                <tr><th>Minimum Number:</th><td> {{form.minimumNumberOfGrains}}</td></tr></table>
+            <tr><th>Minimum Number:</th><td> {{form.minimumNumberOfGrains}}</td></tr></table>
 
-            <P><i>Number of Basis Functions Used in Model (For Chebyshev Only)</i>
+        <P><i>Number of Basis Functions Used in Model (For Chebyshev Only)</i>
             <br><table><tr><th>Temperature:</th><td> {{form.temp_basis}}</td></tr>
             <tr><th>Pressure:</th><td> {{form.p_basis}}</td></tr></table>
-                </li></ol>
+    </li></ol>
+</li></ul>
 
-                </li></ul>
+<P><br>
 
+<ol>
+    <li value="6"><h3>Tolerances</h3>
+    
+    <P>Indicate your allowed flux tolerance for moving a reaction to the core or keeping
+    the reaction on the edge.  In the advanced options, you can set additional tolerances for the solver, and 
+    for the edge reactions (the possible reactions generated from the species in the core).
+    Generally, the edge tolerance is set to zero unless you need to prune the edge to reduce 
+    model generation time.
+    
+    <P><table><tr><th>Core Tolerance:</th><td> {{ form.toleranceMoveToCore }}</td></tr></table>
+</ol>
 
-            <P><br>
-            <ol><li value="6"><h3>Tolerances</h3>
-                    <P>Indicate your allowed flux tolerance for moving a reaction to the core or keeping
-                        the reaction on the edge.  In the advanced options, you can set additional tolerances for the solver, and 
-                        for the edge reactions (the possible reactions generated from the species in the core).
-                        Generally, the edge tolerance is set to zero you need to prune the edge to reduce 
-                        model generation time.
-            <P><table><tr><th>Core Tolerance:</th><td> {{ form.toleranceMoveToCore }}</td></tr></table>
-            </ol>
+<ul id="tolmenu"><li>[x] Advanced Options
+    <ol><li>
+        <table>
+            <tr><th>Edge Tolerance:</th>                          <td>{{ form.toleranceKeepInEdge }}</td></tr>
+            <tr><th>Tolerance to Interrupt Simulation:</th>       <td>{{form.toleranceInterruptSimulation}}</td></tr>
+            <tr><th>Maximum Number of Allowed Edge Species:</th>  <td>{{form.maximumEdgeSpecies}}</td></tr></table>
+            <P><i>Numerical Solver</i>
+                <br><table>
+                <tr><th>Absolute Tolerance: </th>    <td>{{ form.simulator_atol }}</td></tr>
+                <tr><th>Relative Tolerance: </th>    <td>{{ form.simulator_rtol }}</td></tr>
+        </table>
+    </li></ol>
+</li></ul>
 
-            <ul id="tolmenu"><li>[x] Advanced Options
-            <ol><li><table><tr><th>Edge Tolerance: </th><td>{{ form.toleranceKeepInEdge }}</td></tr>
-            <tr><th>Tolerance to Interrupt Simulation:  </th><td>{{form.toleranceInterruptSimulation}}</td></tr>
-                <tr><th>Maximum Number of Allowed Edge Species:  </th><td>{{form.maximumEdgeSpecies}}</td></tr></table>
-                <P><i>Numerical Solver</i>
-                <br><table><tr><th>Absolute Tolerance: </th><td> {{ form.simulator_atol }}</td></tr>
-                <tr><th>Relative Rolerance: </th><td> {{ form.simulator_rtol }}</td></tr></table>
-            </li></ol>
-			</li></ul>
+<P><br>
+    
+<ol>
+    <li value="7"><h3>Generated Species Constraints {{ form.speciesConstraints }}</h3>
+    
+    Optional constraints on allowed species.
+    
+    <P><table>
+        <tr><th>Maximum Carbon Atoms:</th>        <td>{{ form.maximumCarbonAtoms }}</td></tr>
+        <tr><th>Maximum Hydrogen Atoms:</th>      <td>{{ form.maximumHydrogenAtoms }}</td></tr>
+        <tr><th>Maximum Oxygen Atoms:</th>        <td>{{ form.maximumOxygenAtoms }}</td></tr>
+        <tr><th>Maximum Nitrogen Atoms:</th>      <td>{{ form.maximumNitrogenAtoms }}</td></tr>
+        <tr><th>Maximum Silicon Atoms:</th>       <td>{{ form.maximumSiliconAtoms }}</td></tr>
+        <tr><th>Maximum Sulfur Atoms:</th>        <td>{{ form.maximumSulfurAtoms }}</td></tr>
+        <tr><th>Maximum Heavy Atoms:</th>         <td>{{ form.maximumHeavyAtoms }}</td></tr>
+        <tr><th>Maximum Radical Electrons:</th>   <td>{{ form.maximumRadicalElectrons }}</td></tr>
+    </table>
 
-            <P><br>
-            
-            <ol>
-            <li value="7"><h3>Generated Species Constraints {{ form.speciesConstraints }}</h3>
-            Optional constraints on allowed species.
-            
-            <P><table>
-                <tr><th>Maximum Carbon Atoms:</th><td>{{ form.maximumCarbonAtoms }}</td></tr>
-                <tr><th>Maximum Hydrogen Atoms:</th><td>{{ form.maximumHydrogenAtoms }}</td></tr>
-                <tr><th>Maximum Oxygen Atoms:</th><td>{{ form.maximumOxygenAtoms }}</td></tr>
-                <tr><th>Maximum Nitrogen Atoms:</th><td>{{ form.maximumNitrogenAtoms }}</td></tr>
-                <tr><th>Maximum Silicon Atoms:</th><td>{{ form.maximumSiliconAtoms }}</td></tr>
-                <tr><th>Maximum Sulfur Atoms:</th><td>{{ form.maximumSulfurAtoms }}</td></tr>
-                <tr><th>Maximum Heavy Atoms:</th><td>{{ form.maximumHeavyAtoms }}</td></tr>
-                <tr><th>Maximum Radical Electrons:</th><td>{{ form.maximumRadicalElectrons }}</td></tr>
-            </table>
+</ol>
+    
+<ul id="constraintmenu"><li>[x] Advanced Options
+    <ol><li>
+        <table>
+            <tr><th>Allow Input Species:</th>       <td>{{ form.allowed_inputSpecies }}</td></tr>
+            <tr><th>Allow Seed Mechanisms:</th>     <td>{{ form.allowed_seedMechanisms }}</td></tr>
+            <tr><th>Allow Reaction Libraries:</th>  <td>{{ form.allowed_reactionLibraries }}</td></tr>
+            <tr><th>Allow Singlet O2:</th>          <td>{{ form.allowSingletO2 }}</td></tr>
+        </table>
+    </li></ol>
+</li></ul>
 
-            </ol>
-            
-            <ul id="constraintmenu"><li>[x] Advanced Options
-            <ol><li><table>
-            	<tr><th>Allow Input Species:</th><td>{{ form.allowed_inputSpecies }}</td></tr>
-            	<tr><th>Allow Seed Mechanisms:</th><td>{{ form.allowed_seedMechanisms }}</td></tr>
-            	<tr><th>Allow Reaction Libraries:</th><td>{{ form.allowed_reactionLibraries }}</td></tr>
-                <tr><th>Allow Singlet O2:</th><td>{{ form.allowSingletO2 }}</td></tr></table>
-            </li></ol>
-			</li></ul>
+<P><br>
+    
+<ol>
+    <li value="8"><h3>Additional Options</h3>
+    
+    Restart files can be generated automatically during the progress of a RMG-Py job in order to pick up a job in the middle
+    of a run rather than starting completely from scratch if there is a failure or memory issue.              
+    The save restart period may be optionally left empty if no restart files are desired.  
 
-            <P><br>
-            
-            <ol>
-        	<li value="8"><h3>Additional Options</h3>
-        	Restart files can be generated automatically during the progress of a RMG-Py job in order to pick up a job in the middle
-        	of a run rather than starting completely from scratch if there is a failure or memory issue.          	
-        	The save restart period may be optionally left empty if no restart files are desired.  
-        
-            <P><table>
-                <tr><th>Save Restart:</th><td>
-                {{ form.saveRestartPeriod }} {{ form.saveRestartPeriodUnits }}
-                </td></tr>
-                <tr><th>Draw Molecules:</th><td>
-                {{ form.drawMolecules }}</td></tr>
-                <tr><th>Generate Plots:</th><td>
-                {{ form.generatePlots }}</td></tr>
-                <tr><th>Save Concentration Profiles:</th><td>
-                {{ form.saveSimulationProfiles }}</td></tr>
-                <tr><th>Save Edge Species:</th><td>
-                {{ form.saveEdgeSpecies }}</td></tr>
-                <tr><th>Verbose Chemkin Comments:</th><td>
-                {{ form.verboseComments }}</td></tr></table>
-    		</ol>
+    <P><table>
+        <tr><th>Save Restart:</th>                 <td>{{ form.saveRestartPeriod }}{{ form.saveRestartPeriodUnits }}</td></tr>
+        <tr><th>Draw Molecules:</th>               <td>{{ form.drawMolecules }}</td></tr>
+        <tr><th>Generate Plots:</th>               <td>{{ form.generatePlots }}</td></tr>
+        <tr><th>Save Concentration Profiles:</th>  <td>{{ form.saveSimulationProfiles }}</td></tr>
+        <tr><th>Save Edge Species:</th>            <td>{{ form.saveEdgeSpecies }}</td></tr>
+        <tr><th>Verbose Chemkin Comments:</th>     <td>{{ form.verboseComments }}</td></tr>
+    </table>
+</ol>
 
-    <P><br>
-    <blockquote>
-       <input type="submit" value="Submit" name="submit" />
+<P><br>
+
+<blockquote>
+    <input type="submit" value="Submit" name="submit" />
     <P>By pressing submit, you will be prompted to save an input.py file ready for use in RMG-Py.
-        </blockquote>
+</blockquote>
+
 </form>
 </div>
 

--- a/rmgweb/rmg/templates/input.html
+++ b/rmgweb/rmg/templates/input.html
@@ -157,6 +157,12 @@ ul {
   margin: 0;
 }
 
+ ul#constraintmenu ol {
+  display: none;
+  list-style-type: none;
+  margin: 0;
+}
+
  .delete-row {
         margin-left:30px;
         font-weight:bold;
@@ -391,12 +397,40 @@ This is translated into an adjacency list using the <a href="http://cactus.nci.n
                 <br><table><tr><th>Absolute Tolerance: </th><td> {{ form.simulator_atol }}</td></tr>
                 <tr><th>Relative Rolerance: </th><td> {{ form.simulator_rtol }}</td></tr></table>
             </li></ol>
-  </li></ul>
+			</li></ul>
 
             <P><br>
-
+            
             <ol>
-        <li value="7"><h3>Additional Options</h3>
+            <li value="7"><h3>Generated Species Constraints {{ form.speciesConstraints }}</h3>
+            Optional constraints on allowed species.
+            
+            <P><table>
+                <tr><th>Maximum Carbon Atoms:</th><td>{{ form.maximumCarbonAtoms }}</td></tr>
+                <tr><th>Maximum Hydrogen Atoms:</th><td>{{ form.maximumHydrogenAtoms }}</td></tr>
+                <tr><th>Maximum Oxygen Atoms:</th><td>{{ form.maximumOxygenAtoms }}</td></tr>
+                <tr><th>Maximum Nitrogen Atoms:</th><td>{{ form.maximumNitrogenAtoms }}</td></tr>
+                <tr><th>Maximum Silicon Atoms:</th><td>{{ form.maximumSiliconAtoms }}</td></tr>
+                <tr><th>Maximum Sulfur Atoms:</th><td>{{ form.maximumSulfurAtoms }}</td></tr>
+                <tr><th>Maximum Heavy Atoms:</th><td>{{ form.maximumHeavyAtoms }}</td></tr>
+                <tr><th>Maximum Radical Electrons:</th><td>{{ form.maximumRadicalElectrons }}</td></tr>
+            </table>
+
+            </ol>
+            
+            <ul id="constraintmenu"><li>[x] Advanced Options
+            <ol><li><table>
+            	<tr><th>Allow Input Species:</th><td>{{ form.allowed_inputSpecies }}</td></tr>
+            	<tr><th>Allow Seed Mechanisms:</th><td>{{ form.allowed_seedMechanisms }}</td></tr>
+            	<tr><th>Allow Reaction Libraries:</th><td>{{ form.allowed_reactionLibraries }}</td></tr>
+                <tr><th>Allow Singlet O2:</th><td>{{ form.allowSingletO2 }}</td></tr></table>
+            </li></ol>
+			</li></ul>
+
+            <P><br>
+            
+            <ol>
+        	<li value="8"><h3>Additional Options</h3>
         	Restart files can be generated automatically during the progress of a RMG-Py job in order to pick up a job in the middle
         	of a run rather than starting completely from scratch if there is a failure or memory issue.          	
         	The save restart period may be optionally left empty if no restart files are desired.  
@@ -410,8 +444,12 @@ This is translated into an adjacency list using the <a href="http://cactus.nci.n
                 <tr><th>Generate Plots:</th><td>
                 {{ form.generatePlots }}</td></tr>
                 <tr><th>Save Concentration Profiles:</th><td>
-                {{ form.saveSimulationProfiles }}</td></tr></table>
-    </ol>
+                {{ form.saveSimulationProfiles }}</td></tr>
+                <tr><th>Save Edge Species:</th><td>
+                {{ form.saveEdgeSpecies }}</td></tr>
+                <tr><th>Verbose Chemkin Comments:</th><td>
+                {{ form.verboseComments }}</td></tr></table>
+    		</ol>
 
     <P><br>
     <blockquote>

--- a/rmgweb/rmg/templates/input.html
+++ b/rmgweb/rmg/templates/input.html
@@ -420,6 +420,8 @@ If you already have a saved input.py file that you would like to modify, you can
                 <br><table>
                 <tr><th>Absolute Tolerance: </th>    <td>{{ form.simulator_atol }}</td></tr>
                 <tr><th>Relative Tolerance: </th>    <td>{{ form.simulator_rtol }}</td></tr>
+                <tr><th>Sensitivity Absolute Tolerance: </th>    <td>{{ form.simulator_sens_atol }}</td></tr>
+                <tr><th>Sensitivity Relative Tolerance: </th>    <td>{{ form.simulator_sens_rtol }}</td></tr>
         </table>
     </li></ol>
 </li></ul>

--- a/rmgweb/rmg/templates/input.html
+++ b/rmgweb/rmg/templates/input.html
@@ -469,8 +469,15 @@ If you already have a saved input.py file that you would like to modify, you can
         <tr><th>Software:</th>                  <td>{{ form.software }}</td></tr>
         <tr><th>Method:</th>                    <td>{{ form.method }}</td></tr>
         <tr><th>Only Cyclics:</th>              <td>{{ form.onlyCyclics }}</td></tr>
+        <tr><td colspan=2>It is recommended that Only Cyclics is set to True, since it is very time consuming to perform 
+        QM jobs on non-cyclie molecules, and it is likely that group additivity values will be more accurate.</td></tr>
         <tr><th>Maximum Radical Number:</th>    <td>{{ form.maxRadicalNumber }}</td></tr>
+        <tr><td colspan=2>It is recommended that Maximum Radical Number be set to 0, because semi-empirical methods such as 
+        PM3, PM6, and PM7 are generally fitted with nonradical species, and therefore quantum calculations on radical species
+        may not be accurate.  Thermochemistry for radicals is computed by applying a Hydrogen Bond Increment value onto the
+        neutral species to produce the most accurate value.</td></tr>
     </table>
+
 
 </ol>
 

--- a/rmgweb/rmg/templates/input.html
+++ b/rmgweb/rmg/templates/input.html
@@ -441,7 +441,23 @@ If you already have a saved input.py file that you would like to modify, you can
 <P><br>
     
 <ol>
-    <li value="7"><h3>Generated Species Constraints {{ form.speciesConstraints }}</h3>
+    <li value="7"><h3>Quantum Calculations {{ form.quantumCalc }}</h3>
+    
+    Optional block for performing on the fly quantum mechanical calculations to determine thermodynamic parameters.
+    
+    <P><table>
+        <tr><th>Software:</th>                  <td>{{ form.software }}</td></tr>
+        <tr><th>Method:</th>                    <td>{{ form.method }}</td></tr>
+        <tr><th>File Store:</th>                <td>{{ form.fileStore }}</td></tr>
+        <tr><th>Scratch Directory:</th>         <td>{{ form.scratchDirectory }}</td></tr>
+        <tr><th>Only Cyclics:</th>              <td>{{ form.onlyCyclics }}</td></tr>
+        <tr><th>Maximum Radical Number:</th>    <td>{{ form.maxRadicalNumber }}</td></tr>
+    </table>
+
+</ol>
+
+<ol>
+    <li value="8"><h3>Generated Species Constraints {{ form.speciesConstraints }}</h3>
     
     Optional constraints on allowed species.
     
@@ -472,7 +488,7 @@ If you already have a saved input.py file that you would like to modify, you can
 <P><br>
     
 <ol>
-    <li value="8"><h3>Additional Options</h3>
+    <li value="9"><h3>Additional Options</h3>
     
     Restart files can be generated automatically during the progress of a RMG-Py job in order to pick up a job in the middle
     of a run rather than starting completely from scratch if there is a failure or memory issue.              

--- a/rmgweb/rmg/templates/input.html
+++ b/rmgweb/rmg/templates/input.html
@@ -162,6 +162,12 @@ ul {
         list-style-type: none;
         margin: 0;
     }
+    
+    ul#qmmenu ol {
+        display: none;
+        list-style-type: none;
+        margin: 0;
+    }
 
     ul#constraintmenu ol {
         display: none;
@@ -462,13 +468,26 @@ If you already have a saved input.py file that you would like to modify, you can
     <P><table>
         <tr><th>Software:</th>                  <td>{{ form.software }}</td></tr>
         <tr><th>Method:</th>                    <td>{{ form.method }}</td></tr>
-        <tr><th>File Store:</th>                <td>{{ form.fileStore }}</td></tr>
-        <tr><th>Scratch Directory:</th>         <td>{{ form.scratchDirectory }}</td></tr>
         <tr><th>Only Cyclics:</th>              <td>{{ form.onlyCyclics }}</td></tr>
         <tr><th>Maximum Radical Number:</th>    <td>{{ form.maxRadicalNumber }}</td></tr>
     </table>
 
 </ol>
+
+<ul id="qmmenu"><li>Advanced Options
+
+    <ol><li>
+    
+    You may provide user specified directories for where to store thermo files as well as the the temporary scratch files.  The default directories
+    are QMfiles and QMscratch, respectively, in your job directory.   
+        <table>
+        <tr><th>File Store:</th>                <td>{{ form.fileStore }}</td></tr>
+        <tr><th>Scratch Directory:</th>         <td>{{ form.scratchDirectory }}</td></tr>
+        </table>
+    </li></ol>
+</li></ul>
+
+<P><br>
 
 <ol>
     <li value="8"><h3>Generated Species Constraints {{ form.speciesConstraints }}</h3>

--- a/rmgweb/rmg/templates/input.html
+++ b/rmgweb/rmg/templates/input.html
@@ -189,7 +189,6 @@ ul {
 {% endblock %}
 
 {% block navbar_items %}
-<a href="{% url 'rmg.views.index' %}">Simulation and Tools</a> &raquo;
 <a href="{% url 'rmg.views.input' %}">Create Input File</a>
 {% endblock %}
 

--- a/rmgweb/rmg/templates/input.html
+++ b/rmgweb/rmg/templates/input.html
@@ -52,9 +52,9 @@ $(document).ready(function() {
     }
    });
 
-   
+
 // add images to the right of all the text areas
-   $("textarea").closest('td').append("<img src='/media/moleculedraw-logo-small.png' align='middle'></img>");
+   $("textarea").closest('td').append("<img style='float:right' src='/media/moleculedraw-logo-small.png'></img>");
 // add onChange handlers to all the text areas to modify the image sources
    $("textarea").change( function() {
       var src = adjlist2img( $(this).val() );
@@ -96,9 +96,11 @@ $(document).ready(function() {
 
 
 <style type="text/css">
-    table {
-        margin-left:50px;
+
+table {
+    margin-left:50px;
 }
+
 table.contents {
     width: 100%;
     margin-top: 1.3em;
@@ -121,64 +123,98 @@ th {
 table.contents .icon {
     float: left;
 }
+
 table.contents .biglink {
     font-size: 150%;
     text-align: left;
     vertical-align: bottom;
 }
+
 table.contents .linkdesc {
     text-align: left;
     vertical-align: top;
     font-style: italic;
 }
+
 img {
     padding:10px;
 }
+
 ol li {
-        padding:10px;
+    padding:10px;
 }
 
 ul {
-        list-style: none;
-        margin-left: 50px;
-        padding: 0;
-        border: none;
-        }
-
- ul#pdepmenu ol {
-  display: none;
-  list-style-type: none;
-  margin: 0;
+    list-style: none;
+    margin-left: 50px;
+    padding: 0;
+    border: none;
 }
 
- ul#tolmenu ol {
-  display: none;
-  list-style-type: none;
-  margin: 0;
+    ul#pdepmenu ol {
+        display: none;
+        list-style-type: none;
+        margin: 0;
+    }
+
+    ul#tolmenu ol {
+        display: none;
+        list-style-type: none;
+        margin: 0;
+    }
+
+    ul#constraintmenu ol {
+        display: none;
+        list-style-type: none;
+        margin: 0;
+    }
+
+    ul.form li{
+        padding: 7px
+    }
+
+field {
+    width: 150px;
+    display: inline-block;
+    vertical-align: top;
+    font-weight: bold;
+}
+    field#short {
+        width: 100px;
+    }
+
+.delete-row {
+    margin-left:30px;
+    font-weight:bold;
 }
 
- ul#constraintmenu ol {
-  display: none;
-  list-style-type: none;
-  margin: 0;
+.add-row {
+    font-weight:bold;
 }
 
- .delete-row {
-        margin-left:30px;
-        font-weight:bold;
-    }
+#reactor_species .delete-row {
+    margin-left:7px;
+}
 
- .add-row {
-        padding-top:5px;
-        font-weight:bold;
-    }
+#reactor_systems .delete-row {
+    margin-left: 7px;
+}
 
- #reactor_species .delete-row {
-       margin:130px;
-    }
+#reactor_species .add-row {
+    margin-left:10px;
+}
 
- #reactor_systems .delete-row {
-        margin: 200px;
+#reactor_systems .add-row {
+    margin-left: 10px;
+}
+
+blockquote {
+    display: block;
+    margin-top: 1em;
+    margin-bottom: 1em;
+    margin-left: 50px;
+    margin-right: 0px;
+    
 }
 
 </style>
@@ -196,18 +232,17 @@ ul {
 
 {% block page_body %}
 
-
 This form will generate an input file for a RMG-Py job.
-<P><br>
-
+<P>
 
 <hr/>
+
 <P>{% if upload_error %}<h3>{{ upload_error }}</h3>{% endif %}
 
 <p>
 If you already have a saved input.py file that you would like to modify, you can upload it here to load it into the form for easy editing and saving.
-
 </p>
+
 <form enctype="multipart/form-data" action="" method="POST">{% csrf_token %}
 {{ uploadform.as_p }}
 <p><input type="submit" value="Submit" name="upload"/></p>
@@ -279,7 +314,7 @@ If you already have a saved input.py file that you would like to modify, you can
                 <td align="center">{{ form.seedmech }}</td>
                 <td align="center">{{ form.edge }}</td>
             </tr>
-             {% endfor %}
+            {% endfor %}
             {{ reactionlibformset.management_form }}
         </tbody>
     </table>
@@ -291,29 +326,27 @@ If you already have a saved input.py file that you would like to modify, you can
     You can quickly fill in the adjacency list part of the form by entering any species identifier,
     such as a SMILES, InChI, CAS number, or species name in the 'species identifier' field and pressing tab.
     This is translated into an adjacency list using the <a href="http://cactus.nci.nih.gov/chemical/structure">NCI Chemical Identifier Resolver</a>.
-    <P>
     
 </ol>
     
-<ol start="1">
+<ul class="form">
     <table id="reactor_species" border="1" cellpadding ="3" cellspacing ="30" rules="rows">
         <tbody>{% for form in reactorspecformset.forms %}
             <tr id="{{ form.prefix }}-row"><td><li>
-                <b>Species Name:</b> {% for fld in form.hidden_fields %}{{ fld }}{% endfor %}
-                                     {% if form.instance.pk %}{{ form.DELETE }}{% endif %}
-                                     {{ form.name }}
-                <br><b>Species Identifier:</b> {{ form.identifier }}
-                <br><b>Adjacency List:</b>
-                <br>{{ form.adjlist }}
-                <br><b>Mole Fraction:</b> {{form.molefrac}}
-                <br><b>Inert Species:</b> {{ form.inert }}
+                {% for fld in form.hidden_fields %}{{ fld }}{% endfor %}
+                {% if form.instance.pk %}{{ form.DELETE }}{% endif %}
+                <field>Species Name:</field> {{ form.name }}
+                <br><field>Species Identifier:</field> {{ form.identifier }}
+                <br><field>Adjacency List:</field> {{ form.adjlist }}
+                <br><field>Mole Fraction:</field> {{form.molefrac}}
+                <br><field>Inert Species:</field> {{ form.inert }}
             </td><br>
             </tr>
             {% endfor %}
             {{ reactorspecformset.management_form }}
         </tbody>
     </table>
-</ol>
+</ul>
 
 <ol>
     <li value="4"><h3>Reactor Systems</h3>
@@ -327,24 +360,25 @@ If you already have a saved input.py file that you would like to modify, you can
     one of the termination criteria is fulfilled.
 </ol>
 
-<ol start="1">
+<ul class="form">
     <table id="reactor_systems" border="1" cellpadding ="3" cellspacing ="30" rules="rows">
         <tbody>{% for form in reactorformset.forms %}
-            <tr id="{{ form.prefix }}-row"><td><li> {% for fld in form.hidden_fields %}{{ fld }}{% endfor %}
-                {% if form.instance.pk %}{{ form.DELETE }}{% endif %}
-            <b>Temperature:</b> {{ form.temperature }} {{ form.temperature_units }}
-            <br><b>Pressure:</b> {{ form.pressure }} {{ form.pressure_units }}    
+            <tr id="{{ form.prefix }}-row"><td><li>
+            {% for fld in form.hidden_fields %}{{ fld }}{% endfor %}
+            {% if form.instance.pk %}{{ form.DELETE }}{% endif %}
+            <field>Temperature:</field> {{ form.temperature }} {{ form.temperature_units }}
+            <br><field>Pressure:</field> {{ form.pressure }} {{ form.pressure_units }}    
             <P><b>Termination Criteria:</b>
             <blockquote>
-                <b>End Time:</b> {{ form.terminationtime }} {{ form.time_units }}
-                <br><b>Species:</b> {{ form.species }} <b>Conversion:</b> {{ form.conversion }}
+                <field id="short">End Time:</field> {{ form.terminationtime }} {{ form.time_units }}
+                <br><field id="short">Species:</field> {{ form.species }} <b>Conversion:</b> {{ form.conversion }}
             </blockquote>
             </td></tr>
             {% endfor %}
             {{ reactorformset.management_form }}
         </tbody>
     </table>
-</ol>
+</ul>
 
 <ol>
     <li value="5"><h3>Pressure Dependence: {{ form.pdep }}</h3>
@@ -360,7 +394,7 @@ If you already have a saved input.py file that you would like to modify, you can
     </table>
 </ol>
 
-<ul id="pdepmenu"><li>[x] Advanced Options
+<ul id="pdepmenu"><li>Advanced Options
     <ol><li>
         <P><i>Number of Interpolation Points Used in Model</i>
             <br><table><tr><th>Temperature:</th><td> {{ form.temp_interp}}</td></tr>
@@ -390,7 +424,7 @@ If you already have a saved input.py file that you would like to modify, you can
     <P><table><tr><th>Core Tolerance:</th><td> {{ form.toleranceMoveToCore }}</td></tr></table>
 </ol>
 
-<ul id="tolmenu"><li>[x] Advanced Options
+<ul id="tolmenu"><li>Advanced Options
     <ol><li>
         <table>
             <tr><th>Edge Tolerance:</th>                          <td>{{ form.toleranceKeepInEdge }}</td></tr>
@@ -424,7 +458,7 @@ If you already have a saved input.py file that you would like to modify, you can
 
 </ol>
     
-<ul id="constraintmenu"><li>[x] Advanced Options
+<ul id="constraintmenu"><li>Advanced Options
     <ol><li>
         <table>
             <tr><th>Allow Input Species:</th>       <td>{{ form.allowed_inputSpecies }}</td></tr>
@@ -457,8 +491,8 @@ If you already have a saved input.py file that you would like to modify, you can
 <P><br>
 
 <blockquote>
+    <p>By pressing submit, you will be prompted to save an input.py file ready for use in RMG-Py.</p>
     <input type="submit" value="Submit" name="submit" />
-    <P>By pressing submit, you will be prompted to save an input.py file ready for use in RMG-Py.
 </blockquote>
 
 </form>

--- a/rmgweb/rmg/templates/input.html
+++ b/rmgweb/rmg/templates/input.html
@@ -293,7 +293,7 @@ If you already have a saved input.py file that you would like to modify, you can
         </tbody>
     </table>
 
-    <li><h3>Reaction Libraries</h3>
+    <li><h3>Reaction Libraries and Seed Mechanisms</h3>
     
     Select reaction libraries you would like to be included in your RMG job in order of priority. Rates from reactions within the library will be used 
     if the reaction is found in your job. You may select multiple libraries.
@@ -513,7 +513,7 @@ If you already have a saved input.py file that you would like to modify, you can
         <tr><th>Maximum Nitrogen Atoms:</th>      <td>{{ form.maximumNitrogenAtoms }}</td></tr>
         <tr><th>Maximum Silicon Atoms:</th>       <td>{{ form.maximumSiliconAtoms }}</td></tr>
         <tr><th>Maximum Sulfur Atoms:</th>        <td>{{ form.maximumSulfurAtoms }}</td></tr>
-        <tr><th>Maximum Heavy Atoms:</th>         <td>{{ form.maximumHeavyAtoms }}</td></tr>
+        <tr><th>Maximum Heavy Atoms (Non-Hydrogen):</th>         <td>{{ form.maximumHeavyAtoms }}</td></tr>
         <tr><th>Maximum Radical Electrons:</th>   <td>{{ form.maximumRadicalElectrons }}</td></tr>
     </table>
 
@@ -544,7 +544,7 @@ If you already have a saved input.py file that you would like to modify, you can
     <P><table>
         <tr><th>Save Restart:</th>                 <td>{{ form.saveRestartPeriod }}{{ form.saveRestartPeriodUnits }}</td></tr>
         <tr><th>Draw Molecules:</th>               <td>{{ form.drawMolecules }}</td></tr>
-        <tr><th>Generate Plots:</th>               <td>{{ form.generatePlots }}</td></tr>
+        <tr><th>Generate Performance Statistics Plots:</th>               <td>{{ form.generatePlots }}</td></tr>
         <tr><th>Save Concentration Profiles:</th>  <td>{{ form.saveSimulationProfiles }}</td></tr>
         <tr><th>Save Edge Species:</th>            <td>{{ form.saveEdgeSpecies }}</td></tr>
         <tr><th>Verbose Chemkin Comments:</th>     <td>{{ form.verboseComments }}</td></tr>

--- a/rmgweb/rmg/templates/input.html
+++ b/rmgweb/rmg/templates/input.html
@@ -373,6 +373,11 @@ If you already have a saved input.py file that you would like to modify, you can
                 <field id="short">End Time:</field> {{ form.terminationtime }} {{ form.time_units }}
                 <br><field id="short">Species:</field> {{ form.species }} <b>Conversion:</b> {{ form.conversion }}
             </blockquote>
+            <P><b>Sensitivity Analysis:</b>
+            <blockquote>
+                <field id="short">Species:</field> {{ form.sensitivity }}
+                <br><field id="short">Threshold:</field> {{ form.sensitivityThreshold }}
+            </blockquote>
             </td></tr>
             {% endfor %}
             {{ reactorformset.management_form }}

--- a/rmgweb/rmg/templates/inputResult.html
+++ b/rmgweb/rmg/templates/inputResult.html
@@ -6,9 +6,6 @@
 {% block title %}RMG: Input File Generated{% endblock %}
 
 {% block navbar_items %}
-
-<a href="{% url 'rmg.views.index' %}">Simulation and Tools</a> &raquo;
-
 <a href="{% url 'rmg.views.input' %}">Create Input File</a>
 {% endblock %}
 

--- a/rmgweb/rmg/urls.py
+++ b/rmgweb/rmg/urls.py
@@ -53,9 +53,6 @@ urlpatterns = patterns('rmgweb.rmg',
     # Populate Reactions with an Input File
     (r'^populate_reactions','views.runPopulateReactions'),
     
-    # RMG Input Form
-    (r'^input', 'views.input'),
-    
     # Plot Kinetics
     (r'^plot_kinetics', 'views.plotKinetics'),
     

--- a/rmgweb/urls.py
+++ b/rmgweb/urls.py
@@ -87,6 +87,9 @@ urlpatterns = patterns('rmgweb',
     # RMG-Py Stuff
     (r'^simulate/', include('rmg.urls')),
     
+    # RMG Input Form
+    (r'^input', 'rmg.views.input'),
+    
     # Documentation auto-rebuild
     (r'^rebuild$', 'main.views.rebuild'),
 


### PR DESCRIPTION
Major changes:
* Updated additional options to match available options
* Added section for species constraints
* Updated pdep section
* Added QMTP section
* Added sensitivity analysis option for reactor systems
* Updated descriptions, added some links to documentation
* Slightly modified CSS

The form works for loading and writing input files for a variety of cases that I've tested. There could still be specific cases that I missed which break, so please try it out. There is an associated pull request for RMG-Py.

I also tried to add an option to set the interpolation scheme for pdep to False, which is a option according to the documentation. I haven't been able to get it to work yet, so it is not in this pull request. Does interpolation=False currently work properly, and does anyone actually use it?

Desired features to be added:
* Capability to set initial mole fractions for each individual reactor
* Capability to choose which reaction families to use (currently set to default/recommended)