### PR TITLE
Move group draw to /tools/ page

### DIFF
--- a/rmgweb/database/templates/groupDraw.html
+++ b/rmgweb/database/templates/groupDraw.html
@@ -38,10 +38,11 @@ $(document).ready(function() {
 {% endblock %}
 
 {% block navbar_items %}
-<a href="{% url 'database.views.groupDraw' %}">Group Draw</a>
+<a href="{% url 'rmg.views.index' %}">RMG Tools</a> &raquo;
+<a href="{% url 'database.views.groupDraw' %}">Draw Functional Group</a>
 {% endblock %}
 
-{% block page_title %}Group Draw{% endblock %}
+{% block page_title %}Draw Functional Group{% endblock %}
 
 {% block page_body %}
 

--- a/rmgweb/database/templates/groupDraw.html
+++ b/rmgweb/database/templates/groupDraw.html
@@ -7,34 +7,7 @@
 {% block title %}RMG: Group Draw{% endblock %}
 
 {% block extrahead %}
-<script type="text/javascript">
-// the function used to resolve the identifier into an adjacency list
-function resolve(){
-   var spField = $('#id_species');
-   var identifier = $('#id_species_identifier').val();
-   var url = '/adjacencylist/'+escape(identifier);
-   spField.val("Loading...");
-   $('.result').hide();
-   var jqxhr = $.get(url,function(structure) {
-                     spField.val(structure);
-                  })
-               .error(function(j,t,e) { spField.val(t+'\n'+e); });
-};
 
-// prevent "enter" keypress in the identifier field from submitting the form,
-// but instead make it resolve the identifier and select the submit button.
-$(document).ready(function() {
-   $("#id_species_identifier").bind("keypress", function(e) {
-    var c = e.which ? e.which : e.keyCode;
-    if (c == 13) {
-       resolve();
-       $("input:submit:first").focus();
-       return false;
-    }
-   });
-
-}) // end of document.ready
-</script>
 {% endblock %}
 
 {% block navbar_items %}

--- a/rmgweb/rmg/templates/rmg.html
+++ b/rmgweb/rmg/templates/rmg.html
@@ -33,6 +33,7 @@
 		<li><a href="{% url 'rmg.views.plotKinetics' %}">Plot Kinetics</a>: plot forward and reverse kinetics by supplying a list of reactions in chemkin format along with a RMG dictionary.<P>
 		<li><a href="{% url 'rmg.views.javaKineticsLibrary' %}">Create RMG-Java Kinetics Library</a>: create an RMG-Java kinetics library for use as a seed-mechanism or reaction library by supplying a chemkin file along with a RMG dictionary.<P>
 		<li><a href="{% url 'rmg.views.evaluateNASA' %}">Evaluate NASA Polynomial</a>: View enthalpy, entropy, and heat capacity information in human readable format for a CHEMKIN format NASA polynomial.<P>
+		<li><a href="{% url 'database.views.groupDraw' %}">Draw Functional Group</a>: Draw an RMG group definition from its Adjacency List.<P>
 					</ol>
 	
 {% endblock %}

--- a/rmgweb/rmg/urls.py
+++ b/rmgweb/rmg/urls.py
@@ -30,10 +30,13 @@
 
 from django.conf.urls import url, include
 from rmgweb.rmg import views
+import rmgweb.database.views
 
 urlpatterns = [
     # RMG Simulation Homepage
     url(r'^$', views.index),
+
+    url(r'^group_draw', rmgweb.database.views.groupDraw),
 
     # Convert Chemkin File to Output File
     url(r'^chemkin', views.convertChemkin),

--- a/rmgweb/templates/base.html
+++ b/rmgweb/templates/base.html
@@ -55,13 +55,7 @@
         <div class="biglink">Create Input File</div></a>
         <div class="linkdesc">Online form for making an RMG input file</div>
         </p>
-        
-        <p>
-        <a href="{% url 'database.views.groupDraw' %}"><img src="/media/groupdraw-logo-small.png" class="icon" height="32px"/>
-        <div class="biglink">Draw Group</div></a>
-        <div class="linkdesc">Draw a group structure from its adjlist</div>
-        </p>
-        
+                
         <p>
         <a href="{% url 'database.views.moleculeSearch' %}"><img src="/media/moleculedraw-logo-small.png" class="icon" height="32px"/>
         <div class="biglink">Molecule Search</div></a>

--- a/rmgweb/urls.py
+++ b/rmgweb/urls.py
@@ -92,8 +92,7 @@ urlpatterns = [
     url(r'^solvation_search', rmgweb.database.views.solvationSearch),
 
     # RMG-Py Stuff
-    url(r'^simulate/', include('rmgweb.rmg.urls')),
-    url(r'^simulate/input', rmgweb.rmg.views.input),
+    url(r'^tools/', include('rmgweb.rmg.urls')),
     
     # RMG Input Form
     url(r'^input', rmgweb.rmg.views.input),

--- a/rmgweb/urls.py
+++ b/rmgweb/urls.py
@@ -88,7 +88,6 @@ urlpatterns = [
 
     # Molecule and solvation search,  group drawing webpages
     url(r'^molecule_search$', rmgweb.database.views.moleculeSearch),
-    url(r'^group_draw$', rmgweb.database.views.groupDraw),
     url(r'^solvation_search', rmgweb.database.views.solvationSearch),
 
     # RMG-Py Stuff


### PR DESCRIPTION
After #109 this pull request does two things that I propose but people might want to discuss:

1. move the URL of things currently at  /simulate/  to be at /tools/. I think this is a more descriptive name

2. move the group_draw feature from the top level home page to the /tools/ page. This removes it from the sidebar menu, adds it to the tools page menu, and changes its url from /group_draw to /tools/group_draw. I feel it's not one of the most important things for new users and our landing page is overly complicated.