### PR TITLE
Fix Kinetics Search and add filter reactions to Create Input File

### DIFF
--- a/rmgweb/database/tools.py
+++ b/rmgweb/database/tools.py
@@ -40,6 +40,7 @@ import rmgweb.settings
 import pybel
 import openbabel as ob
 import xlrd
+import itertools
 
 
 from rmgpy.kinetics import Arrhenius
@@ -426,6 +427,10 @@ def generateReactions(database, reactants, products=None, only_families=None):
     else:
         rmgJavaReactionList = []
     
+    for rxn in itertools.chain(reactionList, rmgJavaReactionList):
+        rxn.reactants = [Species(molecule=[mol]) if isinstance(mol,Molecule) else mol for mol in rxn.reactants]
+        rxn.products = [Species(molecule=[mol]) if isinstance(mol,Molecule) else mol for mol in rxn.products]
+
     return reactionList, rmgJavaReactionList
     
 ################################################################################

--- a/rmgweb/rmg/models.py
+++ b/rmgweb/rmg/models.py
@@ -521,6 +521,7 @@ class Input(models.Model):
     maximumEdgeSpecies = models.PositiveIntegerField(default = 100000)
     minCoreSizeForPrune = models.PositiveIntegerField(default = 50)
     minSpeciesExistIterationsForPrune = models.PositiveIntegerField(default = 2)
+    filterReactions = models.BooleanField()
     simulator_atol = models.FloatField(default = 1e-16)
     simulator_rtol = models.FloatField(default = 1e-8)
     simulator_sens_atol = models.FloatField(default = 1e-6)
@@ -666,6 +667,7 @@ class Input(models.Model):
         initial['maximumEdgeSpecies'] = self.rmg.maximumEdgeSpecies 
         initial['minCoreSizeForPrune'] = self.rmg.minCoreSizeForPrune
         initial['minSpeciesExistIterationsForPrune'] = self.rmg.minSpeciesExistIterationsForPrune
+        initial['filterReactions'] = self.rmg.filterReactions
                 
         # Pressure Dependence
         if self.rmg.pressureDependence:
@@ -814,6 +816,7 @@ class Input(models.Model):
         self.rmg.maximumEdgeSpecies = form.cleaned_data['maximumEdgeSpecies']
         self.rmg.minCoreSizeForPrune = form.cleaned_data['minCoreSizeForPrune']
         self.rmg.minSpeciesExistIterationsForPrune = form.cleaned_data['minSpeciesExistIterationsForPrune']
+        self.rmg.filterReactions = form.cleaned_data['filterReactions']
         
         # Pressure Dependence
         pdep = form.cleaned_data['pdep'].encode()

--- a/rmgweb/rmg/templates/input.html
+++ b/rmgweb/rmg/templates/input.html
@@ -402,7 +402,9 @@ If you already have a saved input.py file that you would like to modify, you can
     In advanced options, you can set additional tolerances for the solver, and 
     for the edge reactions (the possible reactions generated from the species in the core).
     Generally, the edge tolerance is set to zero unless you need to prune the edge to reduce 
-    model generation time and memory consumption. For more information on pruning, please see the 
+    model generation time and memory consumption. For more information on filtering reactions, 
+    <a href="http://reactionmechanismgenerator.github.io/RMG-Py/users/rmg/input.html#filterreactions" target="_blank">click here</a>.
+    For more information on pruning, please see the 
     <a href="http://reactionmechanismgenerator.github.io/RMG-Py/users/rmg/input.html#pruning" target="_blank">documentation</a>.
     
     <P><table><tr><th>Core Tolerance:</th><td> {{ form.toleranceMoveToCore }}</td></tr></table>
@@ -411,7 +413,7 @@ If you already have a saved input.py file that you would like to modify, you can
 <ul id="tolmenu"><li>Advanced Options
     <ol><li>
         <table>
-            <tr><th>Pre-filter Reactions:</th>                    <td>{{form.filterReactions}}</td></tr></table>
+            <tr><th>Filter Reactions:</th>                    <td>{{form.filterReactions}}</td></tr></table>
              <P><i>Pruning parameters</i>
             <br><table><tr><th>Edge Tolerance:</th>                          <td>{{ form.toleranceKeepInEdge }}</td></tr>
             <tr><th>Tolerance to Interrupt Simulation:</th>       <td>{{form.toleranceInterruptSimulation}}</td></tr>

--- a/rmgweb/rmg/templates/input.html
+++ b/rmgweb/rmg/templates/input.html
@@ -411,7 +411,9 @@ If you already have a saved input.py file that you would like to modify, you can
 <ul id="tolmenu"><li>Advanced Options
     <ol><li>
         <table>
-            <tr><th>Edge Tolerance:</th>                          <td>{{ form.toleranceKeepInEdge }}</td></tr>
+            <tr><th>Pre-filter Reactions:</th>                    <td>{{form.filterReactions}}</td></tr></table>
+             <P><i>Pruning parameters</i>
+            <br><table><tr><th>Edge Tolerance:</th>                          <td>{{ form.toleranceKeepInEdge }}</td></tr>
             <tr><th>Tolerance to Interrupt Simulation:</th>       <td>{{form.toleranceInterruptSimulation}}</td></tr>
             <tr><th>Maximum Number of Allowed Edge Species:</th>  <td>{{form.maximumEdgeSpecies}}</td></tr>
             <tr><th>Minimum Number of Core Species Before Pruning:</th>  <td>{{form.minCoreSizeForPrune}}</td></tr>


### PR DESCRIPTION
Following change in RMG-Py to output family reactions with molecule objects instead of species objects, perform conversion in RMG-website. Fixes #111. 

Also add option for filter reactions to input file form.