### PR TITLE
The entropy in thermo estimation should be standard entropy

### DIFF
--- a/rmgweb/main/templatetags/render_thermo.py
+++ b/rmgweb/main/templatetags/render_thermo.py
@@ -95,7 +95,7 @@ def render_thermo_math(thermo, user=None):
         
         if thermo.S298 is not None:
             result += '<tr>'
-            result += r'    <td class="key"><span class="math">\Delta S_\mathrm{f}^\circ(298 \ \mathrm{K})</span></td>'
+            result += r'    <td class="key"><span class="math">S^\circ(298 \ \mathrm{K})</span></td>'
             result += r'    <td class="equals">=</td>'
             result += r'    <td class="value"><span class="math">{0:.2f} \ \mathrm{{ {1!s} }}</span></td>'.format(thermo.S298.value_si * Sfactor, Sunits)
             result += '</tr>\n'


### PR DESCRIPTION
The notation was wrong for a long time, it should be standard entropy instead of entropy of formation. One can easily test hydrogen, if it's entropy of formation, the value should be zero.

This PR tries to correct the notation, to avoid confusing the users.