### PR TITLE
Update to Django 1.11 and other changes

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,7 @@ dependencies:
   - symmetry
   - mopac
   - graphviz
-  - django ==1.8.4
+  - django >=1.11
   - beautifulsoup4
   - xlrd
   - docutils

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # You will first need RMG-Py installed and working
 
 # These are the additional dependencies
-Django>=1.8.4
+Django>=1.11
 beautifulsoup4
 xlrd
 pydot

--- a/rmgweb/database/forms.py
+++ b/rmgweb/database/forms.py
@@ -331,7 +331,7 @@ class RateEvaluationForm(forms.Form):
     on a set of kinetics.
     """
     #hidden = forms.CharField(widget=forms.HiddenInput())
-    temp_units = (('K','K',),('C','C',))
+    temp_units = (('K','K',),)
     p_units = (('bar','bar',),('torr','torr',),('atm','atm',))
     temperature = forms.FloatField(label="Temperature")    
     temperature_units = forms.ChoiceField(choices=temp_units)

--- a/rmgweb/database/templates/EniSearch.html
+++ b/rmgweb/database/templates/EniSearch.html
@@ -23,7 +23,7 @@ function resolve(fieldName){
 // convert an adjacency list into an image url
 function adjlist2img(s) {
    adjlist = encodeURI(s);
-   return "{% url 'main.views.drawMolecule' adjlist='ADJLIST' %}".replace('ADJLIST',adjlist);
+   return "{% url 'draw-molecule' adjlist='ADJLIST' %}".replace('ADJLIST',adjlist);
 }
 
 $(document).ready(function() {

--- a/rmgweb/database/templates/database.html
+++ b/rmgweb/database/templates/database.html
@@ -7,7 +7,7 @@
 {% block extrahead %}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
+<li><a href="{% url 'database:index' %}">Database</a></li>
 {% endblock %}
 
 {% block sidebar_items %}
@@ -16,46 +16,46 @@
 {% block page_title %}RMG Database{% endblock %}
 
 {% block page_body %}
-<h2><a href="{% url 'database.views.kinetics' %}">Kinetics Database</a></h2>
+<h2><a href="{% url 'database:kinetics' %}">Kinetics Database</a></h2>
 
 <ul>
-<li> <a href="{% url 'database.views.kineticsSearch' %}">Kinetics Search</a></li>
-<li><a href="{% url 'database.views.kinetics' section='libraries' %}">Kinetics Libraries</a></li>
-<li><a href="{% url 'database.views.kinetics' section='families' %}">Kinetics Families</a></li>
+<li> <a href="{% url 'database:kinetics-search' %}">Kinetics Search</a></li>
+<li><a href="{% url 'database:kinetics' section='libraries' %}">Kinetics Libraries</a></li>
+<li><a href="{% url 'database:kinetics' section='families' %}">Kinetics Families</a></li>
 </ul>
 
-<h2><a href="{% url 'database.views.solvation' %}">Solvation Database</a></h2>
+<h2><a href="{% url 'database:solvation' %}">Solvation Database</a></h2>
 
 <ul>
-<li><a href="{% url 'database.views.solvationSearch' %}">Solvation Search</a></li>
-<li><a href="{% url 'database.views.solvation' section='libraries' %}">Solvation Libraries</a></li>
-<li><a href="{% url 'database.views.solvation' section='groups' %}">Solvation Groups</a></li>
+<li><a href="{% url 'database:solvation-search' %}">Solvation Search</a></li>
+<li><a href="{% url 'database:solvation' section='libraries' %}">Solvation Libraries</a></li>
+<li><a href="{% url 'database:solvation' section='groups' %}">Solvation Groups</a></li>
 </ul>
 
-<h2><a href="{% url 'database.views.statmech' %}">Statmech Database</a></h2>
+<h2><a href="{% url 'database:statmech' %}">Statmech Database</a></h2>
 
 <ul>
-<li><a href="{% url 'database.views.moleculeSearch' %}">Statmech Search</a></li>
-<li><a href="{% url 'database.views.statmech' section='depository' %}">Statmech Depository</a></li>
-<li><a href="{% url 'database.views.statmech' section='libraries' %}">Statmech Libraries</a></li>
-<li><a href="{% url 'database.views.statmech' section='groups' %}">Statmech Groups</a></li>
+<li><a href="{% url 'molecule-search' %}">Statmech Search</a></li>
+<li><a href="{% url 'database:statmech' section='depository' %}">Statmech Depository</a></li>
+<li><a href="{% url 'database:statmech' section='libraries' %}">Statmech Libraries</a></li>
+<li><a href="{% url 'database:statmech' section='groups' %}">Statmech Groups</a></li>
 </ul>
 
-<h2><a href="{% url 'database.views.thermo' %}">Thermodynamics Database</a></h2>
+<h2><a href="{% url 'database:thermo' %}">Thermodynamics Database</a></h2>
 
 <ul>
-<li><a href="{% url 'database.views.moleculeSearch' %}">Species Thermodynamics Search</a></li>
-<li><a href="{% url 'database.views.thermo' section='depository' %}">Thermodynamics Depository</a></li>
-<li><a href="{% url 'database.views.thermo' section='libraries' %}">Thermodynamics Libraries</a></li>
-<li><a href="{% url 'database.views.thermo' section='groups' %}">Thermodynamics Groups</a></li>
+<li><a href="{% url 'molecule-search' %}">Species Thermodynamics Search</a></li>
+<li><a href="{% url 'database:thermo' section='depository' %}">Thermodynamics Depository</a></li>
+<li><a href="{% url 'database:thermo' section='libraries' %}">Thermodynamics Libraries</a></li>
+<li><a href="{% url 'database:thermo' section='groups' %}">Thermodynamics Groups</a></li>
 </ul>
 
-<h2><a href="{% url 'database.views.transport' %}">Transport Database</a></h2>
+<h2><a href="{% url 'database:transport' %}">Transport Database</a></h2>
 
 <ul>
-<li><a href="{% url 'database.views.moleculeSearch' %}">Transport Search</a></li>
-<li><a href="{% url 'database.views.transport' section='libraries' %}">Transport Libraries</a></li>
-<li><a href="{% url 'database.views.transport' section='groups' %}">Transport Groups</a></li>
+<li><a href="{% url 'molecule-search' %}">Transport Search</a></li>
+<li><a href="{% url 'database:transport' section='libraries' %}">Transport Libraries</a></li>
+<li><a href="{% url 'database:transport' section='groups' %}">Transport Groups</a></li>
 </ul>
 
 <h3><a href="https://github.com/ReactionMechanismGenerator/RMG-database/archive/{{ dc }}.zip" target="_blank">Download Database</a></h3>

--- a/rmgweb/database/templates/groupDraw.html
+++ b/rmgweb/database/templates/groupDraw.html
@@ -11,8 +11,8 @@
 {% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'rmg.views.index' %}">RMG Tools</a></li>
-<li><a href="{% url 'database.views.groupDraw' %}">Draw Functional Group</a></li>
+<li><a href="{% url 'rmg:index' %}">RMG Tools</a></li>
+<li><a href="{% url 'rmg:group-draw' %}">Draw Functional Group</a></li>
 {% endblock %}
 
 {% block page_title %}Draw Functional Group{% endblock %}

--- a/rmgweb/database/templates/groupEntry.html
+++ b/rmgweb/database/templates/groupEntry.html
@@ -38,7 +38,7 @@ $(document).ready(function() {
 {% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.groupDraw' %}">Group Draw</a></li>
+<li><a href="{% url 'rmg:group-draw' %}">Group Draw</a></li>
 {% endblock %}
 
 {% block page_title %}Group Information{% endblock %}

--- a/rmgweb/database/templates/groupEntry.html
+++ b/rmgweb/database/templates/groupEntry.html
@@ -50,6 +50,10 @@ $(document).ready(function() {
 <th>Group Structure:</th>
 <td style="padding: 40px;">{{ structure|safe }}</td>
 </tr>
+<tr>
+    <th>SVG File:</th>
+    <td><a href="{% url 'draw-group' group.toAdjacencyList 'svg' %}">Click to download</a></td>
+</tr>
 
 <tr class="result">
 <th valign="top">Adjacency List:</th>

--- a/rmgweb/database/templates/kinetics.html
+++ b/rmgweb/database/templates/kinetics.html
@@ -15,10 +15,10 @@ RMG Kinetics Database
 {% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.kinetics' %}">Kinetics</a></li>
-{% if section != '' %}<li><a href="{% url 'database.views.kinetics' section=section %}">{{ section|title }}</a></li>{% endif %}
-{% if subsection != '' %}<li><a href="{% url 'database.views.kinetics' section=section subsection=subsection %}">{{ subsection|title }}</a></li>{% endif %}
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:kinetics' %}">Kinetics</a></li>
+{% if section != '' %}<li><a href="{% url 'database:kinetics' section=section %}">{{ section|title }}</a></li>{% endif %}
+{% if subsection != '' %}<li><a href="{% url 'database:kinetics' section=section subsection=subsection %}">{{ subsection|title }}</a></li>{% endif %}
 {% endblock %}
 
 {% block sidebar_items %}
@@ -36,9 +36,9 @@ RMG Kinetics Database
 
 
 {% if section == '' %}
-<h2>1. <a href="{% url 'database.views.kineticsSearch' %}">Search Reaction Kinetics</a></h2>
+<h2>1. <a href="{% url 'database:kinetics-search' %}">Search Reaction Kinetics</a></h2>
 
-<h2>2. <a href="{% url 'database.views.kinetics' section='libraries' %}">Kinetics Libraries</a></h2>
+<h2>2. <a href="{% url 'database:kinetics' section='libraries' %}">Kinetics Libraries</a></h2>
 {% endif %}
 
 {% if section == 'libraries' or section == '' %}
@@ -47,7 +47,7 @@ RMG Kinetics Database
 <table class="kineticsData">
 {% for subsection, library in kineticsLibraries %}
     <tr>
-        <td><a href="{% url 'database.views.kinetics' section='libraries' subsection=subsection %}">{{ library.label }}</a></td>
+        <td><a href="{% url 'database:kinetics' section='libraries' subsection=subsection %}">{{ library.label }}</a></td>
         <td>({{ library.entries|length }} entries)</td>
         <td>{{ library.shortDesc}}</td>
     </tr>
@@ -57,7 +57,7 @@ RMG Kinetics Database
 {% endif %}
 
 {% if section == '' %}
-<h2>3. <a href="{% url 'database.views.kinetics' section='families' %}">Kinetics Families</a></h2>
+<h2>3. <a href="{% url 'database:kinetics' section='families' %}">Kinetics Families</a></h2>
 {% endif %}
 
 {% if section == 'families' or section == '' %}
@@ -65,16 +65,16 @@ RMG Kinetics Database
 <table class="kineticsData">
 {% for subsection, family in kineticsFamilies %}
     <tr>
-        <td><a href="{% url 'database.views.kinetics' section='families' subsection=subsection %}">{{ family.name }}</a></td>
+        <td><a href="{% url 'database:kinetics' section='families' subsection=subsection %}">{{ family.name }}</a></td>
         <td>        
         	<ul>
-            <li><a href="{% url 'database.views.kinetics' section='families' subsection=family.groups.label %}">{{ family.groups.name }}</a> ({{ family.groups.entries|length }} entries)</li>
+            <li><a href="{% url 'database:kinetics' section='families' subsection=family.groups.label %}">{{ family.groups.name }}</a> ({{ family.groups.entries|length }} entries)</li>
             {% if family.rules.entries %}
-            <li><a href="{% url 'database.views.kinetics' section='families' subsection=family.rules.label %}">{{ family.rules.name }}</a> ({{ family.rules.entries|length }} entries)</li>
+            <li><a href="{% url 'database:kinetics' section='families' subsection=family.rules.label %}">{{ family.rules.name }}</a> ({{ family.rules.entries|length }} entries)</li>
             {% endif %}
             {% for depository in family.depositories %}
             {% if depository.entries %}
-            <li><a href="{% url 'database.views.kinetics' section='families' subsection=depository.label %}">{{ depository.name }}</a> ({{ depository.entries|length }} entries)</li>
+            <li><a href="{% url 'database:kinetics' section='families' subsection=depository.label %}">{{ depository.name }}</a> ({{ depository.entries|length }} entries)</li>
             {% endif %}
             {% endfor %}
         	</ul>

--- a/rmgweb/database/templates/kineticsData.html
+++ b/rmgweb/database/templates/kineticsData.html
@@ -173,9 +173,9 @@ function insertSquib() {
 {% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.kinetics' %}">Kinetics</a></li>
-<li><a href="{% url 'database.views.kineticsSearch' %}">Search</a></li>
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:kinetics' %}">Kinetics</a></li>
+<li><a href="{% url 'database:kinetics-search' %}">Search</a></li>
 {% endblock %}
 
 {% block sidebar_items %}
@@ -233,7 +233,7 @@ function insertSquib() {
 </div>
 {% if new_entry_form %}
 <div align="right">
-    <form name="SquibForm" onSubmit="insertSquib()" action="{% url 'database.views.kineticsEntryNew' family=subsection type="NIST" %}" method="POST">
+    <form name="SquibForm" onSubmit="insertSquib()" action="{% url 'database:kinetics-entry-new' family=subsection type="NIST" %}" method="POST">
         {% csrf_token %}
         Have NIST data for this reaction? Enter the squib here to import it:
         <input type=text value="" id="id_new_squib">
@@ -268,7 +268,7 @@ Result #{{ forloop.counter }} - {{ source }}{% if entry.index != -1 %}/{{entry.i
 <div id="plotk" style="width: {{ plotWidth }}px; height: {{ plotHeight }}px; margin: auto;"></div>
 
 {% if new_entry_form %}
-<form method="post" id="entry_form" onSubmit="calculateAverage()" action="{% url 'database.views.kineticsEntryNew' family=subsection type="training" %}">
+<form method="post" id="entry_form" onSubmit="calculateAverage()" action="{% url 'database:kinetics-entry-new' family=subsection type="training" %}">
 <div style="display: none;">{{ new_entry_form.entry }}</div>
 {% csrf_token %}
 <div align="center">

--- a/rmgweb/database/templates/kineticsEntry.html
+++ b/rmgweb/database/templates/kineticsEntry.html
@@ -93,7 +93,7 @@ jQuery(document).ready(
 <li><a href="{% url 'database:kinetics' %}">Kinetics</a></li>
 <li><a href="{% url 'database:kinetics' section=section %}">{{ section|title }}</a></li>
 <li><a href="{% url 'database:kinetics' section=section subsection=subsection %}">{{ databaseName }}</a></li>
-{% if entry and entry.index and entry.index != -1 %}<li><a href="{% url 'database:kinetics=entry' section=section subsection=subsection index=entry.index %}">{{ entry.index }}. {{ entry.label }}</a></li>{% endif %}
+{% if entry and entry.index and entry.index != -1 %}<li><a href="{% url 'database:kinetics-entry' section=section subsection=subsection index=entry.index %}">{{ entry.index }}. {{ entry.label }}</a></li>{% endif %}
 {% if reaction %}<li><a href="">{{ reaction }}</a></li>{% endif %}
 {% endif %}
 

--- a/rmgweb/database/templates/kineticsEntry.html
+++ b/rmgweb/database/templates/kineticsEntry.html
@@ -89,11 +89,11 @@ jQuery(document).ready(
 {% block navbar_items %}
 
 {% if section != '' %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.kinetics' %}">Kinetics</a></li>
-<li><a href="{% url 'database.views.kinetics' section=section %}">{{ section|title }}</a></li>
-<li><a href="{% url 'database.views.kinetics' section=section subsection=subsection %}">{{ databaseName }}</a></li>
-{% if entry and entry.index and entry.index != -1 %}<li><a href="{% url 'database.views.kineticsEntry' section=section subsection=subsection index=entry.index %}">{{ entry.index }}. {{ entry.label }}</a></li>{% endif %}
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:kinetics' %}">Kinetics</a></li>
+<li><a href="{% url 'database:kinetics' section=section %}">{{ section|title }}</a></li>
+<li><a href="{% url 'database:kinetics' section=section subsection=subsection %}">{{ databaseName }}</a></li>
+{% if entry and entry.index and entry.index != -1 %}<li><a href="{% url 'database:kinetics=entry' section=section subsection=subsection index=entry.index %}">{{ entry.index }}. {{ entry.label }}</a></li>{% endif %}
 {% if reaction %}<li><a href="">{{ reaction }}</a></li>{% endif %}
 {% endif %}
 
@@ -175,14 +175,14 @@ jQuery(document).ready(
 
 <h2>Update database</h2>
 If you noticed a mistake or have better data, then edit this entry here:
-    <a href="{% url 'database.views.kineticsEntryEdit' section=section subsection=subsection index=entry.index %}">
+    <a href="{% url 'database:kinetics-entry-edit' section=section subsection=subsection index=entry.index %}">
         <button type="button">Edit entry</button>
     </a>.
 
 {% if user.is_authenticated %}
 You are logged in as {{ user.get_full_name }}</a> 
 {% else %}
-You must <a href="{% url 'main.views.login' %}?next={{ request.path }}">log in first.</a>
+You must <a href="{% url 'login' %}?next={{ request.path }}">log in first.</a>
 {% endif %}
 
 {% endif %}

--- a/rmgweb/database/templates/kineticsResults.html
+++ b/rmgweb/database/templates/kineticsResults.html
@@ -9,9 +9,9 @@
 {% block extrahead %}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.kinetics' %}">Kinetics</a></li>
-<li><a href="{% url 'database.views.kineticsSearch' %}">Search</a></li>
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:kinetics' %}">Kinetics</a></li>
+<li><a href="{% url 'database:kinetics-search' %}">Search</a></li>
 <li><a href="">Results</a></li>
 {% endblock %}
 

--- a/rmgweb/database/templates/kineticsResults.html
+++ b/rmgweb/database/templates/kineticsResults.html
@@ -22,16 +22,26 @@
 
 {% block page_body %}
 
-<table class="kineticsData">
-{% for reactants, arrow, products, count, reactionUrl in reactionDataList %}
-    <tr>
-        <td><a href="{{ reactionUrl }}">{{ forloop.counter }}.</a></td>
-        <td class="reactants">{{ reactants|safe }}</td>
-        <td class="reactionArrow">{{ arrow|safe }}</td>
-        <td class="products">{{ products|safe }}</td>
-        <td><a href="{{ reactionUrl }}">{{ count }} result{% if count > 1 %}s{% endif %}</a></td>
-    </tr>
-{% endfor %}
-</table>
+{% if reactionDataList %}
+    <table class="kineticsData">
+    {% for reactants, arrow, products, count, reactionUrl in reactionDataList %}
+        <tr>
+            <td><a href="{{ reactionUrl }}">{{ forloop.counter }}.</a></td>
+            <td class="reactants">{{ reactants|safe }}</td>
+            <td class="reactionArrow">{{ arrow|safe }}</td>
+            <td class="products">{{ products|safe }}</td>
+            <td><a href="{{ reactionUrl }}">{{ count }} result{% if count > 1 %}s{% endif %}</a></td>
+        </tr>
+    {% endfor %}
+    </table>
+{% else %}
+    <h2>
+        No results found.
+    </h2>
+    <p>
+        Our database could not find any reactions between these two species which give new products.
+        If you think this is an error, please <a href="https://github.com/ReactionMechanismGenerator/RMG-Py/issues/new/choose">post an issue</a> on our GitHub page.
+    </p>
+{% endif %}
 
 {% endblock %}

--- a/rmgweb/database/templates/kineticsSearch.html
+++ b/rmgweb/database/templates/kineticsSearch.html
@@ -25,7 +25,7 @@ function resolve(fieldName){
 // convert an adjancency list into an image url
 function adjlist2img(s) {
    adjlist = encodeURI(s);
-   return "{% url 'main.views.drawMolecule' adjlist='ADJLIST' %}".replace('ADJLIST',adjlist);
+   return "{% url 'draw-molecule' adjlist='ADJLIST' %}".replace('ADJLIST',adjlist);
 }
 
 $(document).ready(function() {
@@ -59,9 +59,9 @@ $(document).ready(function() {
 {% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.kinetics' %}">Kinetics</a></li>
-<li><a href="{% url 'database.views.kineticsSearch' %}">Search</a></li>
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:kinetics' %}">Kinetics</a></li>
+<li><a href="{% url 'database:kinetics-search' %}">Search</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/database/templates/kineticsTable.html
+++ b/rmgweb/database/templates/kineticsTable.html
@@ -56,10 +56,10 @@ span.kineticsDatumLabel {
 {% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.kinetics' %}">Kinetics</a></li>
-<li><a href="{% url 'database.views.kinetics' section=section %}">{{ section|title }}</a></li>
-<li><a href="{% url 'database.views.kinetics' section=section subsection=subsection %}">{{ databaseName }}</a></li>
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:kinetics' %}">Kinetics</a></li>
+<li><a href="{% url 'database:kinetics' section=section %}">{{ section|title }}</a></li>
+<li><a href="{% url 'database:kinetics' section=section subsection=subsection %}">{{ databaseName }}</a></li>
 {% endblock %}
 
 {% block sidebar_items %}
@@ -131,7 +131,7 @@ $(document).ready(function() {
             </tr>
             {% for entry in entries %}
             <tr>
-                <td><a href="{% url 'database.views.kineticsEntry' section=section subsection=subsection index=entry.index %}">{{ entry.index }}. {{ entry.label }}</a></td>
+                <td><a href="{% url 'database:kinetics-entry' section=section subsection=subsection index=entry.index %}">{{ entry.index }}. {{ entry.label }}</a></td>
                 <td class="reactants">{{ entry.reactants|safe }}</td>
                 <td class="reactionArrow">{{ entry.arrow|safe }}</td>
                 <td class="products">{{ entry.products|safe }}</td>

--- a/rmgweb/database/templates/moleculeEntry.html
+++ b/rmgweb/database/templates/moleculeEntry.html
@@ -57,6 +57,11 @@ var jqxhr = $.get(url,function(names) { $('#species_names').html(names);})
 <th>Molecule Structure:</th>
 <td style="padding: 40px;">{{ structure|safe }}</td>
 </tr>
+<tr>
+    <th>SVG File:</th>
+    <td><a href="{% url 'draw-molecule' molecule.toAdjacencyList 'svg' %}">Click to download</a></td>
+</tr>
+
 <tr class ="result">
     <th>Molecular Weight:</th>
     <td>{{ molecule.getMolecularWeight|renderMW }}</td>

--- a/rmgweb/database/templates/moleculeEntry.html
+++ b/rmgweb/database/templates/moleculeEntry.html
@@ -44,7 +44,7 @@ var jqxhr = $.get(url,function(names) { $('#species_names').html(names);})
 {% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.moleculeSearch' %}">Molecule Search</a></li>
+<li><a href="{% url 'molecule-search' %}">Molecule Search</a></li>
 {% endblock %}
 
 {% block page_title %}Molecule Information{% endblock %}
@@ -64,12 +64,12 @@ var jqxhr = $.get(url,function(names) { $('#species_names').html(names);})
 <tr class ="result">
     <th>Thermochemistry:</th>
     <td>
-<a href="{% url 'database.views.thermoData' molecule.toAdjacencyList %}">Click here</a></td>
+<a href="{% url 'database:thermo-data' molecule.toAdjacencyList %}">Click here</a></td>
 </tr>
 <tr class ="result">
     <th>Transport:</th>
     <td>
-<a href="{% url 'database.views.transportData' molecule.toAdjacencyList %}">Click here</a></td>
+<a href="{% url 'database:transport-data' molecule.toAdjacencyList %}">Click here</a></td>
 </tr>
 
 <tr class="result">

--- a/rmgweb/database/templates/moleculeSearch.html
+++ b/rmgweb/database/templates/moleculeSearch.html
@@ -128,7 +128,7 @@ function submitMolecule() {
 {% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.moleculeSearch' %}">Molecule Search</a></li>
+<li><a href="{% url 'molecule-search' %}">Molecule Search</a></li>
 {% endblock %}
 
 {% block page_title %}Molecule Search{% endblock %}

--- a/rmgweb/database/templates/solvation.html
+++ b/rmgweb/database/templates/solvation.html
@@ -13,10 +13,10 @@ RMG Solvation Database
 {% block extrahead %}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.solvation' %}">solvation</a></li>
-{% if section != '' %}<li><a href="{% url 'database.views.solvation' section=section %}">{{ section|title }}</a></li>
-{% if subsection != '' %}<li><a href="{% url 'database.views.solvation' section=section subsection=subsection %}">{{ subsection|title }}</a></li>{% endif %}
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:solvation' %}">solvation</a></li>
+{% if section != '' %}<li><a href="{% url 'database:solvation' section=section %}">{{ section|title }}</a></li>
+{% if subsection != '' %}<li><a href="{% url 'database:solvation' section=section subsection=subsection %}">{{ subsection|title }}</a></li>{% endif %}
 {% endif %}
 {% endblock %}
 
@@ -34,31 +34,31 @@ RMG Solvation Database
 {% block page_body %}
 
 {% if section == '' %}
-<h2>1. <a href="{% url 'database.views.solvationSearch' %}">Solvation Search</a></h2>
+<h2>1. <a href="{% url 'database:solvation-search' %}">Solvation Search</a></h2>
 {% endif %}
 
 {% if section == '' %}
-<h2>2. <a href="{% url 'database.views.solvation' section='libraries' %}">Solvation Libraries</a></h2>
+<h2>2. <a href="{% url 'database:solvation' section='libraries' %}">Solvation Libraries</a></h2>
 {% endif %}
 
 {% if section == 'libraries' or section == '' %}
 <ul>
 {% for subsection, library in solvationLibraries %}
-<li><a href="{% url 'database.views.solvation' section='libraries' subsection=subsection %}">{{ library.name }}</a> ({{ library.entries|length }} entries)</li>
+<li><a href="{% url 'database:solvation' section='libraries' subsection=subsection %}">{{ library.name }}</a> ({{ library.entries|length }} entries)</li>
 {% endfor %}
 </ul>
 {% endif %}
 
 {% if section == '' %}
-<h2>3. <a href="{% url 'database.views.solvation' section='groups' %}"> Solvation Groups</a></h2>
+<h2>3. <a href="{% url 'database:solvation' section='groups' %}"> Solvation Groups</a></h2>
 {% endif %}
 
 {% if section == 'groups' or section == '' %}
 <ul>
-    {# <li><a href="{% url 'database.views.solvation' section='groups' subsection='group' %}">{{ solvationDatabase.groups.group.name }}</a> ({{ solvationDatabase.groups.group.entries|length }} entries)</li> #}
+    {# <li><a href="{% url 'database:solvation' section='groups' subsection='group' %}">{{ solvationDatabase.groups.group.name }}</a> ({{ solvationDatabase.groups.group.entries|length }} entries)</li> #}
 {% for subsection, groups in solvationGroups %}
     {% if subsection != 'group' %}
-        <li><a href="{% url 'database.views.solvation' section='groups' subsection=subsection %}">{{ groups.label }}</a> ({{ groups.entries|length }} entries)</li>
+        <li><a href="{% url 'database:solvation' section='groups' subsection=subsection %}">{{ groups.label }}</a> ({{ groups.entries|length }} entries)</li>
     {% endif %}
 {% endfor %}
 

--- a/rmgweb/database/templates/solvationData.html
+++ b/rmgweb/database/templates/solvationData.html
@@ -13,8 +13,8 @@
 {% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.solvation' %}">Solvation</a></li>
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:solvation' %}">Solvation</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/database/templates/solvationEntry.html
+++ b/rmgweb/database/templates/solvationEntry.html
@@ -44,11 +44,11 @@ table.solvationEntryData td.reference p {
 {% endblock extrahead%}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.solvation' %}">Solvation</a></li>
-<li><a href="{% url 'database.views.solvation' section=section %}">{{ section|title }}</a></li>
-<li><a href="{% url 'database.views.solvation' section=section subsection=subsection %}">{{ subsection }}</a></li>
-{% if entry.index and entry.index != -1 %}<li><a href="{% url 'database.views.solvationEntry' section=section subsection=subsection index=entry.index %}">{{ entry.index }}. {{ entry.label }}</a></li>{% endif %}
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:solvation' %}">Solvation</a></li>
+<li><a href="{% url 'database:solvation' section=section %}">{{ section|title }}</a></li>
+<li><a href="{% url 'database:solvation' section=section subsection=subsection %}">{{ subsection }}</a></li>
+{% if entry.index and entry.index != -1 %}<li><a href="{% url 'database:solvation-entry' section=section subsection=subsection index=entry.index %}">{{ entry.index }}. {{ entry.label }}</a></li>{% endif %}
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/database/templates/solvationSearch.html
+++ b/rmgweb/database/templates/solvationSearch.html
@@ -24,7 +24,7 @@ function resolve(){
 // convert an adjancency list into an image url
 function adjlist2img(s) {
    adjlist = encodeURI(s);
-   return "{% url 'main.views.drawMolecule' adjlist='ADJLIST' %}".replace('ADJLIST',adjlist);
+   return "{% url 'draw-molecule' adjlist='ADJLIST' %}".replace('ADJLIST',adjlist);
 }
 
 $(document).ready(function() {
@@ -57,7 +57,7 @@ $(document).ready(function() {
 {% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.solvationSearch' %}">Solvation Search</a></li>
+<li><a href="{% url 'database:solvation-search' %}">Solvation Search</a></li>
 {% endblock %}
 
 {% block page_title %}Solvation Search{% endblock %}
@@ -71,8 +71,8 @@ Select the solvent molecule you would like to be included
 in your solvation estimation in the drop down menu. 
 </p>
 
-<P>You can browse the available solute molecules here: <a href="{% url 'database.views.solvation' section='libraries' subsection='solute' %}" target="_blank">Solute Molecules</a>
-<P>You can browse the available solvent molecules here: <a href="{% url 'database.views.solvation' section='libraries' subsection='solvent' %}" target="_blank">Solvent Molecules</a>
+<P>You can browse the available solute molecules here: <a href="{% url 'database:solvation' section='libraries' subsection='solute' %}" target="_blank">Solute Molecules</a>
+<P>You can browse the available solvent molecules here: <a href="{% url 'database:solvation' section='libraries' subsection='solvent' %}" target="_blank">Solvent Molecules</a>
 
 <P>Any solute can be used in this search form.  The search will pull the solute data if it exists in the library, otherwise it will estimate the solvation
 properties using the Abraham parameters to perform group estimation.  

--- a/rmgweb/database/templates/solvationTable.html
+++ b/rmgweb/database/templates/solvationTable.html
@@ -13,10 +13,10 @@ RMG Solvation Database
 {% block extrahead %}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.solvation' %}">Solvation</a></li>
-<li><a href="{% url 'database.views.solvation' section=section %}">{{ section|title }}</a></li>
-<li><a href="{% url 'database.views.solvation' section=section subsection=subsection %}">{{ databaseName }}</a></li>
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:solvation' %}">Solvation</a></li>
+<li><a href="{% url 'database:solvation' section=section %}">{{ section|title }}</a></li>
+<li><a href="{% url 'database:solvation' section=section subsection=subsection %}">{{ databaseName }}</a></li>
 {% endblock %}
 
 {% block sidebar_items %}
@@ -35,7 +35,7 @@ RMG Solvation Database
 
 {% for index, label, structure, dataFormat in entries %}
 <tr>
-    <td><a href="{% url 'database.views.solvationEntry' section=section subsection=subsection index=index %}">{{ index }}. {{ label }}</a></td>
+    <td><a href="{% url 'database:solvation-entry' section=section subsection=subsection index=index %}">{{ index }}. {{ label }}</a></td>
     <td>{{ structure|safe }}</td>
     <td>{{ dataFormat }}</td>
 </tr>

--- a/rmgweb/database/templates/statmech.html
+++ b/rmgweb/database/templates/statmech.html
@@ -13,10 +13,10 @@ RMG Statmech Database
 {% block extrahead %}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.statmech' %}">statmech</a></li>
-{% if section != '' %}<li><a href="{% url 'database.views.statmech' section=section %}">{{ section|title }}</a></li>
-{% if subsection != '' %}<li><a href="{% url 'database.views.statmech' section=section subsection=subsection %}">{{ subsection|title }}</a></li>{% endif %}
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:statmech' %}">statmech</a></li>
+{% if section != '' %}<li><a href="{% url 'database:statmech' section=section %}">{{ section|title }}</a></li>
+{% if subsection != '' %}<li><a href="{% url 'database:statmech' section=section subsection=subsection %}">{{ subsection|title }}</a></li>{% endif %}
 {% endif %}
 {% endblock %}
 
@@ -34,17 +34,17 @@ RMG Statmech Database
 {% block page_body %}
 
 {% if section == '' %}
-<h2>1. <a href="{% url 'database.views.moleculeSearch' %}">Statmech Search</a></h2>
+<h2>1. <a href="{% url 'molecule-search' %}">Statmech Search</a></h2>
 {% endif %}
 
 {% if section == '' %}
-<h2>2. <a href="{% url 'database.views.statmech' section='depository' %}">Statmech Depository</a></h2>
+<h2>2. <a href="{% url 'database:statmech' section='depository' %}">Statmech Depository</a></h2>
 {% endif %}
 
 {% if section == 'depository' or section == '' %}
 <ul>
 {% for subsection, depository in statmechDepository %}
-<li><a href="{% url 'database.views.statmech' section='depository' subsection=subsection %}">{{ depository.name }}</a> ({{ depository.entries|length }} entries)</li>
+<li><a href="{% url 'database:statmech' section='depository' subsection=subsection %}">{{ depository.name }}</a> ({{ depository.entries|length }} entries)</li>
 
 {% empty %}
 No statmech depositories found.
@@ -55,13 +55,13 @@ No statmech depositories found.
 {% endif %}
 
 {% if section == '' %}
-<h2>3. <a href="{% url 'database.views.statmech' section='libraries' %}">Statmech Libraries</a></h2>
+<h2>3. <a href="{% url 'database:statmech' section='libraries' %}">Statmech Libraries</a></h2>
 {% endif %}
 
 {% if section == 'libraries' or section == '' %}
 <ul>
 {% for subsection, library in statmechLibraries %}
-<li><a href="{% url 'database.views.statmech' section='libraries' subsection=subsection %}">{{ library.name }}</a> ({{ library.entries|length }} entries)</li>
+<li><a href="{% url 'database:statmech' section='libraries' subsection=subsection %}">{{ library.name }}</a> ({{ library.entries|length }} entries)</li>
 
 
 {% empty %}
@@ -74,14 +74,14 @@ No statmech libraries found.
 {% endif %}
 
 {% if section == '' %}
-<h2>4. <a href="{% url 'database.views.statmech' section='groups' %}"> Statmech Groups</a></h2>
+<h2>4. <a href="{% url 'database:statmech' section='groups' %}"> Statmech Groups</a></h2>
 {% endif %}
 
 {% if section == 'groups' or section == '' %}
 <ul>
    {% for subsection, groups in statmechGroups %}
     {% if subsection != 'group' %}
-        <li><a href="{% url 'database.views.statmech' section='groups' subsection=subsection %}">{{ groups.name }}</a> ({{ groups.entries|length }} entries)</li>
+        <li><a href="{% url 'database:statmech' section='groups' subsection=subsection %}">{{ groups.name }}</a> ({{ groups.entries|length }} entries)</li>
     {% endif %}
     {% empty %}
     No statmech groups found.

--- a/rmgweb/database/templates/statmechData.html
+++ b/rmgweb/database/templates/statmechData.html
@@ -13,8 +13,8 @@
 {% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.statmech' %}">Statmech</a></li>
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:statmech' %}">Statmech</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/database/templates/statmechEntry.html
+++ b/rmgweb/database/templates/statmechEntry.html
@@ -44,11 +44,11 @@ table.statmechEntryData td.reference p {
 {% endblock extrahead%}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.statmech' %}">Statmech</a></li>
-<li><a href="{% url 'database.views.statmech' section=section %}">{{ section|title }}</a></li>
-<li><a href="{% url 'database.views.statmech' section=section subsection=subsection %}">{{ subsection }}</a></li>
-{% if entry.index and entry.index != -1 %}<li><a href="{% url 'database.views.statmechEntry' section=section subsection=subsection index=entry.index %}">{{ entry.index }}. {{ entry.label }}</a></li>{% endif %}
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:statmech' %}">Statmech</a></li>
+<li><a href="{% url 'database:statmech' section=section %}">{{ section|title }}</a></li>
+<li><a href="{% url 'database:statmech' section=section subsection=subsection %}">{{ subsection }}</a></li>
+{% if entry.index and entry.index != -1 %}<li><a href="{% url 'database:statmech-entry' section=section subsection=subsection index=entry.index %}">{{ entry.index }}. {{ entry.label }}</a></li>{% endif %}
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/database/templates/statmechTable.html
+++ b/rmgweb/database/templates/statmechTable.html
@@ -13,10 +13,10 @@ RMG Statmech Database
 {% block extrahead %}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.statmech' %}">Statmech</a></li>
-<li><a href="{% url 'database.views.statmech' section=section %}">{{ section|title }}</a></li>
-<li><a href="{% url 'database.views.statmech' section=section subsection=subsection %}">{{ databaseName }}</a></li>
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:statmech' %}">Statmech</a></li>
+<li><a href="{% url 'database:statmech' section=section %}">{{ section|title }}</a></li>
+<li><a href="{% url 'database:statmech' section=section subsection=subsection %}">{{ databaseName }}</a></li>
 {% endblock %}
 
 {% block sidebar_items %}
@@ -35,7 +35,7 @@ RMG Statmech Database
 
 {% for index, label, structure, dataFormat in entries %}
 <tr>
-    <td><a href="{% url 'database.views.statmechEntry' section=section subsection=subsection index=index %}">{{ index }}. {{ label }}</a></td>
+    <td><a href="{% url 'database:statmech-entry' section=section subsection=subsection index=index %}">{{ index }}. {{ label }}</a></td>
     <td>{{ structure|safe }}</td>
     <td>{{ dataFormat }}</td>
 </tr>

--- a/rmgweb/database/templates/thermo.html
+++ b/rmgweb/database/templates/thermo.html
@@ -13,10 +13,10 @@ RMG Thermodynamics Database
 {% block extrahead %}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.thermo' %}">Thermodynamics</a></li>
-{% if section != '' %}<li><a href="{% url 'database.views.thermo' section=section %}">{{ section|title }}</a></li>{% endif %}
-{% if subsection != '' %}<li><a href="{% url 'database.views.thermo' section=section subsection=subsection %}">{{ subsection|title }}</a></li>{% endif %}
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:thermo' %}">Thermodynamics</a></li>
+{% if section != '' %}<li><a href="{% url 'database:thermo' section=section %}">{{ section|title }}</a></li>{% endif %}
+{% if subsection != '' %}<li><a href="{% url 'database:thermo' section=section subsection=subsection %}">{{ subsection|title }}</a></li>{% endif %}
 {% endblock %}
 
 {% block sidebar_items %}
@@ -33,41 +33,41 @@ RMG Thermodynamics Database
 {% block page_body %}
 
 {% if section == '' %}
-<h2>1. <a href="{% url 'database.views.moleculeSearch' %}">Species Thermochemistry Search</a></h2>
+<h2>1. <a href="{% url 'molecule-search' %}">Species Thermochemistry Search</a></h2>
 {% endif %}
 
 {% if section == '' %}
-<h2>2. <a href="{% url 'database.views.thermo' section='depository' %}">Thermodynamics Depository</a></h2>
+<h2>2. <a href="{% url 'database:thermo' section='depository' %}">Thermodynamics Depository</a></h2>
 {% endif %}
 
 {% if section == 'depository' or section == '' %}
 <ul>
 {% for subsection, depository in thermoDepository %}
-<li><a href="{% url 'database.views.thermo' section='depository' subsection=subsection %}">{{ depository.name }}</a> ({{ depository.entries|length }} entries)</li>
+<li><a href="{% url 'database:thermo' section='depository' subsection=subsection %}">{{ depository.name }}</a> ({{ depository.entries|length }} entries)</li>
 {% endfor %}
 </ul>
 {% endif %}
 
 {% if section == '' %}
-<h2>3. <a href="{% url 'database.views.thermo' section='libraries' %}">Thermodynamics Libraries</a></h2>
+<h2>3. <a href="{% url 'database:thermo' section='libraries' %}">Thermodynamics Libraries</a></h2>
 {% endif %}
 
 {% if section == 'libraries' or section == '' %}
 <ul>
 {% for subsection, library in thermoLibraries %}
-<li><a href="{% url 'database.views.thermo' section='libraries' subsection=subsection %}">{{ library.label }}</a> ({{ library.entries|length }} entries)</li>
+<li><a href="{% url 'database:thermo' section='libraries' subsection=subsection %}">{{ library.label }}</a> ({{ library.entries|length }} entries)</li>
 {% endfor %}
 </ul>
 {% endif %}
 
 {% if section == '' %}
-<h2>4. <a href="{% url 'database.views.thermo' section='groups' %}">Thermodynamics Groups</a></h2>
+<h2>4. <a href="{% url 'database:thermo' section='groups' %}">Thermodynamics Groups</a></h2>
 {% endif %}
 
 {% if section == 'groups' or section == '' %}
 <ul>
 {% for subsection, groups in thermoGroups %}
-    <li><a href="{% url 'database.views.thermo' section='groups' subsection=subsection %}">{{ groups.name }}</a> ({{ groups.entries|length }} entries)</li>
+    <li><a href="{% url 'database:thermo' section='groups' subsection=subsection %}">{{ groups.name }}</a> ({{ groups.entries|length }} entries)</li>
 {% endfor %}
 </ul>
 {% endif %}

--- a/rmgweb/database/templates/thermoData.html
+++ b/rmgweb/database/templates/thermoData.html
@@ -19,7 +19,7 @@ jQuery(document).ready(function() {
     Sseries = new Array();
     Gseries = new Array();
     
-    {% for entry, thermo, source, href in thermoDataList %}
+    {% for entry, thermo, source, href, nasa in thermoDataList %}
     {{ thermo|get_thermo_data:user }}
     {% include "thermoModel.js" %}
     {% endfor %}
@@ -36,8 +36,8 @@ jQuery(document).ready(function() {
 {% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.thermo' %}">Thermodynamics</a></li>
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:thermo' %}">Thermodynamics</a></li>
 {% endblock %}
 
 {% block sidebar_items %}
@@ -52,15 +52,15 @@ jQuery(document).ready(function() {
 </p>
 If you have thermodynamic data to contribute to this species, you can add an entry here: 
 {% if molecule.getRadicalCount == 0 %}
-<a href="{% url 'database.views.thermoEntryNew' section='depository' subsection='stable' adjlist=molecule.toAdjacencyList %}"><button type="button">Add new entry</button></a>.
+<a href="{% url 'database:thermo-entry-new' section='depository' subsection='stable' adjlist=molecule.toAdjacencyList %}"><button type="button">Add new entry</button></a>.
 {% else %}
-<a href="{% url 'database.views.thermoEntryNew' section='depository' subsection='radical' adjlist=molecule.toAdjacencyList %}"><button type="button">Add new entry</button></a>.
+<a href="{% url 'database:thermo-entry-new' section='depository' subsection='radical' adjlist=molecule.toAdjacencyList %}"><button type="button">Add new entry</button></a>.
 {% endif %}
 
 {% if user.is_authenticated %}
 You are logged in as {{ user.get_full_name }}</a> 
 {% else %}
-You must <a href="{% url 'main.views.login' %}?next={{ request.path }}">log in first.</a>
+You must <a href="{% url 'login' %}?next={{ request.path }}">log in first.</a>
 {% endif %}
 <br/><br/>
 

--- a/rmgweb/database/templates/thermoEntry.html
+++ b/rmgweb/database/templates/thermoEntry.html
@@ -65,11 +65,11 @@ jQuery(document).ready(function() {
 {% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.thermo' %}">Thermodynamics</a></li>
-<li><a href="{% url 'database.views.thermo' section=section %}">{{ section|title }}</a></li>
-<li><a href="{% url 'database.views.thermo' section=section subsection=subsection %}">{{ databaseName }}</a></li>
-{% if entry.index and entry.index != -1 %}<li><a href="{% url 'database.views.thermoEntry' section=section subsection=subsection index=entry.index %}">{{ entry.index }}. {{ entry.label }}</a></li>{% endif %}
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:thermo' %}">Thermodynamics</a></li>
+<li><a href="{% url 'database:thermo' section=section %}">{{ section|title }}</a></li>
+<li><a href="{% url 'database:thermo' section=section subsection=subsection %}">{{ databaseName }}</a></li>
+{% if entry.index and entry.index != -1 %}<li><a href="{% url 'database:thermo-entry' section=section subsection=subsection index=entry.index %}">{{ entry.index }}. {{ entry.label }}</a></li>{% endif %}
 {% endblock %}
 
 {% block sidebar_items %}
@@ -93,7 +93,7 @@ No structure given.
 <table class="thermoEntryData">
 <tr>
     <td class="key">Link:</td>
-    <td class="value"><a href="{% url 'database.views.thermoEntry' section=section subsection=subsection index=thermo.1 %}">{{ entry.data }}</a></td>
+    <td class="value"><a href="{% url 'database:thermo-entry' section=section subsection=subsection index=thermo.1 %}">{{ entry.data }}</a></td>
 </tr>
 </table>
 {% else %}
@@ -121,12 +121,12 @@ CHEMKIN format NASA Polynomial:
 <br/>
 
 {% if entry.index and entry.index != -1 %}
-If you noticed a mistake or have better data, then edit this entry here: <a href="{% url 'database.views.thermoEntryEdit' section=section subsection=subsection index=entry.index %}"><button type="button">Edit entry</button></a>.
+If you noticed a mistake or have better data, then edit this entry here: <a href="{% url 'database:thermo-entry-edit' section=section subsection=subsection index=entry.index %}"><button type="button">Edit entry</button></a>.
 {% endif %}
 {% if user.is_authenticated %}
 You are logged in as {{ user.get_full_name }}</a> 
 {% else %}
-You must <a href="{% url 'main.views.login' %}?next={{ request.path }}">log in first.</a>
+You must <a href="{% url 'login' %}?next={{ request.path }}">log in first.</a>
 {% endif %}
 <br/>
 

--- a/rmgweb/database/templates/thermoTable.html
+++ b/rmgweb/database/templates/thermoTable.html
@@ -13,10 +13,10 @@ RMG Thermodynamics Database
 {% block extrahead %}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.thermo' %}">Thermodynamics</a></li>
-<li><a href="{% url 'database.views.thermo' section=section %}">{{ section|title }}</a></li>
-<li><a href="{% url 'database.views.thermo' section=section subsection=subsection %}">{{ databaseName }}</a></li>
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:thermo' %}">Thermodynamics</a></li>
+<li><a href="{% url 'database:thermo' section=section %}">{{ section|title }}</a></li>
+<li><a href="{% url 'database:thermo' section=section subsection=subsection %}">{{ databaseName }}</a></li>
 {% endblock %}
 
 {% block sidebar_items %}
@@ -34,7 +34,7 @@ RMG Thermodynamics Database
 </tr>
 {% for index, label, structure, dataFormat in entries %}
 <tr>
-    <td><a href="{% url 'database.views.thermoEntry' section=section subsection=subsection index=index %}">{{ index }}. {{ label }}</a></td>
+    <td><a href="{% url 'database:thermo-entry' section=section subsection=subsection index=index %}">{{ index }}. {{ label }}</a></td>
     <td>{{ structure|safe }}</td>
     <td>{{ dataFormat }}</td>
 </tr>

--- a/rmgweb/database/templates/transport.html
+++ b/rmgweb/database/templates/transport.html
@@ -13,10 +13,10 @@ RMG Transport Database
 {% block extrahead %}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.transport' %}">Transport</a></li>
-{% if section != '' %}<li><a href="{% url 'database.views.transport' section=section %}">{{ section|title }}</a></li>
-{% if subsection != '' %}<li><a href="{% url 'database.views.transport' section=section subsection=subsection %}">{{ subsection|title }}</a></li>{% endif %}
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:transport' %}">Transport</a></li>
+{% if section != '' %}<li><a href="{% url 'database:transport' section=section %}">{{ section|title }}</a></li>
+{% if subsection != '' %}<li><a href="{% url 'database:transport' section=section subsection=subsection %}">{{ subsection|title }}</a></li>{% endif %}
 {% endif %}
 {% endblock %}
 
@@ -34,31 +34,31 @@ RMG Transport Database
 {% block page_body %}
 
 {% if section == '' %}
-<h2>1. <a href="{% url 'database.views.moleculeSearch' %}">Transport Search</a></h2>
+<h2>1. <a href="{% url 'molecule-search' %}">Transport Search</a></h2>
 {% endif %}
 
 {% if section == '' %}
-<h2>2. <a href="{% url 'database.views.transport' section='libraries' %}">Transport Libraries</a></h2>
+<h2>2. <a href="{% url 'database:transport' section='libraries' %}">Transport Libraries</a></h2>
 {% endif %}
 
 {% if section == 'libraries' or section == '' %}
 <ul>
 {% for subsection, library in transportLibraries %}
-<li><a href="{% url 'database.views.transport' section='libraries' subsection=subsection %}">{{ library.label }}</a> ({{ library.entries|length }} entries)</li>
+<li><a href="{% url 'database:transport' section='libraries' subsection=subsection %}">{{ library.label }}</a> ({{ library.entries|length }} entries)</li>
 {% endfor %}
 </ul>
 {% endif %}
 
 {% if section == '' %}
-<h2>3. <a href="{% url 'database.views.transport' section='groups' %}"> Transport Groups</a></h2>
+<h2>3. <a href="{% url 'database:transport' section='groups' %}"> Transport Groups</a></h2>
 {% endif %}
 
 {% if section == 'groups' or section == '' %}
 <ul>
-    {# <li><a href="{% url 'database.views.transport' section='groups' subsection='group' %}">{{ transportDatabase.groups.group.name }}</a> ({{ transportDatabase.groups.group.entries|length }} entries)</li> #}
+    {# <li><a href="{% url 'database:transport' section='groups' subsection='group' %}">{{ transportDatabase.groups.group.name }}</a> ({{ transportDatabase.groups.group.entries|length }} entries)</li> #}
 {% for subsection, groups in transportGroups %}
     {% if subsection != 'group' %}
-        <li><a href="{% url 'database.views.transport' section='groups' subsection=subsection %}">{{ groups.label }}</a> ({{ groups.entries|length }} entries)</li>
+        <li><a href="{% url 'database:transport' section='groups' subsection=subsection %}">{{ groups.label }}</a> ({{ groups.entries|length }} entries)</li>
     {% endif %}
 {% endfor %}
 

--- a/rmgweb/database/templates/transportData.html
+++ b/rmgweb/database/templates/transportData.html
@@ -13,8 +13,8 @@
 {% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.transport' %}">Transport</a></li>
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:transport' %}">Transport</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/database/templates/transportEntry.html
+++ b/rmgweb/database/templates/transportEntry.html
@@ -44,11 +44,11 @@ table.transportEntryData td.reference p {
 {% endblock extrahead%}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.transport' %}">Transport</a></li>
-<li><a href="{% url 'database.views.transport' section=section %}">{{ section|title }}</a></li>
-<li><a href="{% url 'database.views.transport' section=section subsection=subsection %}">{{ subsection }}</a></li>
-{% if entry.index and entry.index != -1 %}<li><a href="{% url 'database.views.transportEntry' section=section subsection=subsection index=entry.index %}">{{ entry.index }}. {{ entry.label }}</a></li>{% endif %}
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:transport' %}">Transport</a></li>
+<li><a href="{% url 'database:transport' section=section %}">{{ section|title }}</a></li>
+<li><a href="{% url 'database:transport' section=section subsection=subsection %}">{{ subsection }}</a></li>
+{% if entry.index and entry.index != -1 %}<li><a href="{% url 'database:transport-entry' section=section subsection=subsection index=entry.index %}">{{ entry.index }}. {{ entry.label }}</a></li>{% endif %}
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/database/templates/transportTable.html
+++ b/rmgweb/database/templates/transportTable.html
@@ -13,10 +13,10 @@ RMG Transport Database
 {% block extrahead %}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'database.views.index' %}">Database</a></li>
-<li><a href="{% url 'database.views.transport' %}">Transport</a></li>
-<li><a href="{% url 'database.views.transport' section=section %}">{{ section|title }}</a></li>
-<li><a href="{% url 'database.views.transport' section=section subsection=subsection %}">{{ databaseName }}</a></li>
+<li><a href="{% url 'database:index' %}">Database</a></li>
+<li><a href="{% url 'database:transport' %}">Transport</a></li>
+<li><a href="{% url 'database:transport' section=section %}">{{ section|title }}</a></li>
+<li><a href="{% url 'database:transport' section=section subsection=subsection %}">{{ databaseName }}</a></li>
 {% endblock %}
 
 {% block sidebar_items %}
@@ -34,7 +34,7 @@ RMG Transport Database
 </tr>
 {% for index, label, structure, dataFormat in entries %}
 <tr>
-    <td><a href="{% url 'database.views.transportEntry' section=section subsection=subsection index=index %}">{{ index }}. {{ label }}</a></td>
+    <td><a href="{% url 'database:transport-entry' section=section subsection=subsection index=index %}">{{ index }}. {{ label }}</a></td>
     <td>{{ structure|safe }}</td>
     <td>{{ dataFormat }}</td>
 </tr>

--- a/rmgweb/database/urls.py
+++ b/rmgweb/database/urls.py
@@ -32,75 +32,76 @@ import itertools
 from django.conf.urls import url, include
 from rmgweb.database import views
 
+app_name = 'database'
 
 urlpatterns = [ 
 
     # Database homepage
-    url(r'^$', views.index),
+    url(r'^$', views.index, name='index'),
     
     # Load the whole database into memory
-    url(r'^load/?$', views.load),
+    url(r'^load/?$', views.load, name='load'),
     
     # Export to an RMG-Java database
-    url(r'^export_(?P<type>zip|tar\.gz)/?$', views.export),
+    url(r'^export_(?P<type>zip|tar\.gz)/?$', views.export, name='export'),
 
     # Thermodynamics database
-    url(r'^thermo/$', views.thermo),
-    url(r'^thermo/search/$', views.moleculeSearch),
-    url(r'^thermo/molecule/(?P<adjlist>[\S\s]+)$', views.thermoData),
-    url(r'^thermo/(?P<section>\w+)/(?P<subsection>.+)/(?P<index>-?\d+)/$', views.thermoEntry),
-    url(r'^thermo/(?P<section>\w+)/(?P<subsection>.+)/(?P<adjlist>[\S\s]+)/new$', views.thermoEntryNew),
-    url(r'^thermo/(?P<section>\w+)/(?P<subsection>.+)/(?P<index>-?\d+)/edit$', views.thermoEntryEdit),
-    url(r'^thermo/(?P<section>\w+)/(?P<subsection>.+)/$', views.thermo),
-    url(r'^thermo/(?P<section>\w+)/$', views.thermo),
+    url(r'^thermo/$', views.thermo, name='thermo'),
+    url(r'^thermo/search/$', views.moleculeSearch, name='thermo-search'),
+    url(r'^thermo/molecule/(?P<adjlist>[\S\s]+)$', views.thermoData, name='thermo-data'),
+    url(r'^thermo/(?P<section>\w+)/(?P<subsection>.+)/(?P<index>-?\d+)/$', views.thermoEntry, name='thermo-entry'),
+    url(r'^thermo/(?P<section>\w+)/(?P<subsection>.+)/(?P<adjlist>[\S\s]+)/new$', views.thermoEntryNew, name='thermo-entry-new'),
+    url(r'^thermo/(?P<section>\w+)/(?P<subsection>.+)/(?P<index>-?\d+)/edit$', views.thermoEntryEdit, name='thermo-entry-edit'),
+    url(r'^thermo/(?P<section>\w+)/(?P<subsection>.+)/$', views.thermo, name='thermo'),
+    url(r'^thermo/(?P<section>\w+)/$', views.thermo, name='thermo'),
     
     # Transport database
-    url(r'^transport/$', views.transport),
-    url(r'^transport/search/$', views.moleculeSearch),
-    url(r'^transport/molecule/(?P<adjlist>[\S\s]+)$', views.transportData),
-    url(r'^transport/(?P<section>\w+)/(?P<subsection>.+)/(?P<index>-?\d+)/$', views.transportEntry),
-    url(r'^transport/(?P<section>\w+)/(?P<subsection>.+)/$', views.transport),
-    url(r'^transport/(?P<section>\w+)/$', views.transport),    
+    url(r'^transport/$', views.transport, name='transport'),
+    url(r'^transport/search/$', views.moleculeSearch, name='transport-search'),
+    url(r'^transport/molecule/(?P<adjlist>[\S\s]+)$', views.transportData, name='transport-data'),
+    url(r'^transport/(?P<section>\w+)/(?P<subsection>.+)/(?P<index>-?\d+)/$', views.transportEntry, name='transport-entry'),
+    url(r'^transport/(?P<section>\w+)/(?P<subsection>.+)/$', views.transport, name='transport'),
+    url(r'^transport/(?P<section>\w+)/$', views.transport, name='transport'),
     
     # solvation database
-    url(r'^solvation/$', views.solvation),
-    url(r'^solvation/search/$', views.solvationSearch),    
-    url(r'^solvation/results/solute=(?P<solute_adjlist>[\S\s]+)__solvent=(?P<solvent>[\S\s]+)$', views.solvationData),    
-    url(r'^solvation/(?P<section>\w+)/(?P<subsection>.+)/(?P<index>-?\d+)/$', views.solvationEntry),
-    url(r'^solvation/(?P<section>\w+)/(?P<subsection>.+)/$', views.solvation),
-    url(r'^solvation/(?P<section>\w+)/$', views.solvation),   
+    url(r'^solvation/$', views.solvation, name='solvation'),
+    url(r'^solvation/search/$', views.solvationSearch, name='solvation-search'),
+    url(r'^solvation/results/solute=(?P<solute_adjlist>[\S\s]+)__solvent=(?P<solvent>[\S\s]+)$', views.solvationData, name='solvation-data'),
+    url(r'^solvation/(?P<section>\w+)/(?P<subsection>.+)/(?P<index>-?\d+)/$', views.solvationEntry, name='solvation-entry'),
+    url(r'^solvation/(?P<section>\w+)/(?P<subsection>.+)/$', views.solvation, name='solvation'),
+    url(r'^solvation/(?P<section>\w+)/$', views.solvation, name='solvation'),
     
     # statmech database
-    url(r'^statmech/$', views.statmech),
-    url(r'^statmech/search/$', views.moleculeSearch),
-    url(r'^statmech/molecule/(?P<adjlist>[\S\s]+)$', views.statmechData),
-    url(r'^statmech/(?P<section>\w+)/(?P<subsection>.+)/(?P<index>-?\d+)/$', views.statmechEntry),
-    url(r'^statmech/(?P<section>\w+)/(?P<subsection>.+)/$', views.statmech),
-    url(r'^statmech/(?P<section>\w+)/$', views.statmech), 
+    url(r'^statmech/$', views.statmech, name='statmech'),
+    url(r'^statmech/search/$', views.moleculeSearch, name='statmech-search'),
+    url(r'^statmech/molecule/(?P<adjlist>[\S\s]+)$', views.statmechData, name='statmech-data'),
+    url(r'^statmech/(?P<section>\w+)/(?P<subsection>.+)/(?P<index>-?\d+)/$', views.statmechEntry, name='statmech-entry'),
+    url(r'^statmech/(?P<section>\w+)/(?P<subsection>.+)/$', views.statmech, name='statmech'),
+    url(r'^statmech/(?P<section>\w+)/$', views.statmech, name='statmech'),
     
     # Kinetics database
-    url(r'^kinetics/$', views.kinetics),
-    url(r'^kinetics/search/$', views.kineticsSearch),
+    url(r'^kinetics/$', views.kinetics, name='kinetics'),
+    url(r'^kinetics/search/$', views.kineticsSearch, name='kinetics-search'),
 
-    url(r'^kinetics/families/(?P<family>[^/]+)/(?P<type>\w+)/new$', views.kineticsEntryNew),
-    url(r'^kinetics/families/(?P<family>[^/]+)/untrained/$', views.kineticsUntrained),
+    url(r'^kinetics/families/(?P<family>[^/]+)/(?P<type>\w+)/new$', views.kineticsEntryNew, name='kinetics-entry-new'),
+    url(r'^kinetics/families/(?P<family>[^/]+)/untrained/$', views.kineticsUntrained, name='kinetics-untrained'),
     
-    url(r'^kinetics/(?P<section>\w+)/(?P<subsection>.+)/(?P<index>\d+)/edit$', views.kineticsEntryEdit),
-    url(r'^kinetics/(?P<section>\w+)/(?P<subsection>.+)/(?P<index>-?\d+)/$', views.kineticsEntry),
-    url(r'^kinetics/(?P<section>\w+)/(?P<subsection>.+)/$', views.kinetics),
-    url(r'^kinetics/(?P<section>\w+)/$', views.kinetics),
+    url(r'^kinetics/(?P<section>\w+)/(?P<subsection>.+)/(?P<index>\d+)/edit$', views.kineticsEntryEdit, name='kinetics-entry-edit'),
+    url(r'^kinetics/(?P<section>\w+)/(?P<subsection>.+)/(?P<index>-?\d+)/$', views.kineticsEntry, name='kinetics-entry'),
+    url(r'^kinetics/(?P<section>\w+)/(?P<subsection>.+)/$', views.kinetics, name='kinetics'),
+    url(r'^kinetics/(?P<section>\w+)/$', views.kinetics, name='kinetics'),
     
     # Molecule Information Page
-    url(r'^molecule/(?P<adjlist>[\S\s]+)$', views.moleculeEntry),
+    url(r'^molecule/(?P<adjlist>[\S\s]+)$', views.moleculeEntry, name='molecule-entry'),
     
     #Group Information Page
-    url(r'^group/(?P<adjlist>[\S\s]+)$', views.groupEntry),
+    url(r'^group/(?P<adjlist>[\S\s]+)$', views.groupEntry, name='group-entry'),
 
     # Eni detergent-dirt binding strength
-    url(r'^eni', views.EniSearch),
+    url(r'^eni', views.EniSearch, name='eni-search'),
 
     # AJAX request url
-    url(r'^ajax_adjlist_request', views.json_to_adjlist),
+    url(r'^ajax_adjlist_request', views.json_to_adjlist, name='json-to-adjlist'),
 
     # Remember to update the /media/robots.txt file to keep web-crawlers out of pages you don't want indexed.
 ]
@@ -127,7 +128,7 @@ for r2, r3, p1, p2, p3, res in itertools.product([1, 0], repeat=6):
     if res: url_pattern += url_parts[6]
     url_pattern += r'$'
 
-    urlpatterns.append(url(url_pattern, views.kineticsResults))
+    urlpatterns.append(url(url_pattern, views.kineticsResults, name='kinetics-results'))
 
 for r2, r3, p1, p2, p3, res in itertools.product([1, 0], repeat=6):
     url_pattern = r'^kinetics/reaction/'
@@ -140,7 +141,7 @@ for r2, r3, p1, p2, p3, res in itertools.product([1, 0], repeat=6):
     if res: url_pattern += url_parts[6]
     url_pattern += r'$'
 
-    urlpatterns.append(url(url_pattern, views.kineticsData))
+    urlpatterns.append(url(url_pattern, views.kineticsData, name='kinetics-data'))
 
 for r2, p2, res in itertools.product([1, 0], repeat=3):
     url_pattern = r'^kinetics/families/(?P<family>[^/]+)/(?P<estimator>[^/]+)/'
@@ -151,4 +152,4 @@ for r2, p2, res in itertools.product([1, 0], repeat=3):
     if res: url_pattern += url_parts[6]
     url_pattern += r'$'
 
-    urlpatterns.append(url(url_pattern, views.kineticsGroupEstimateEntry))
+    urlpatterns.append(url(url_pattern, views.kineticsGroupEstimateEntry, name='kinetics-group'))

--- a/rmgweb/database/views.py
+++ b/rmgweb/database/views.py
@@ -47,7 +47,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseRedirect, HttpResponse
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import RequestContext
 
 import rmgpy
@@ -86,13 +86,13 @@ def load(request):
     Load the RMG database and redirect to the database homepage.
     """
     database.load()
-    return HttpResponseRedirect(reverse(index))
+    return HttpResponseRedirect(reverse('database:index'))
 
 def index(request):
     """
     The RMG database homepage.
     """
-    return render_to_response('database.html', context_instance=RequestContext(request))
+    return render(request, 'database.html')
 
 def export(request, type):
     """
@@ -183,7 +183,7 @@ def transport(request, section='', subsection=''):
                 
             entries.append((entry.index,entry.label,structure,dataFormat))
 
-        return render_to_response('transportTable.html', {'section': section, 'subsection': subsection, 'databaseName': db.name, 'entries': entries}, context_instance=RequestContext(request))
+        return render(request, 'transportTable.html', {'section': section, 'subsection': subsection, 'databaseName': db.name, 'entries': entries})
 
     else:
         # No subsection was specified, so render an outline of the transport
@@ -192,7 +192,7 @@ def transport(request, section='', subsection=''):
         transportLibraries.sort()
         transportGroups = [(label, groups) for label, groups in database.transport.groups.iteritems()]
         transportGroups.sort()
-        return render_to_response('transport.html', {'section': section, 'subsection': subsection, 'transportLibraries': transportLibraries, 'transportGroups': transportGroups}, context_instance=RequestContext(request))
+        return render(request, 'transport.html', {'section': section, 'subsection': subsection, 'transportLibraries': transportLibraries, 'transportGroups': transportGroups})
     
 def transportEntry(request, section, subsection, index):
     """
@@ -220,7 +220,7 @@ def transportEntry(request, section, subsection, index):
             index = min(entry.index for entry in db.entries.values() if entry.index > 0)
         else:
             index = max(entry.index for entry in db.entries.values() if entry.index > 0)
-        return HttpResponseRedirect(reverse(transportEntry,
+        return HttpResponseRedirect(reverse('database:transport-entry',
                                             kwargs={'section': section,
                                                     'subsection': subsection,
                                                     'index': index,
@@ -239,7 +239,7 @@ def transportEntry(request, section, subsection, index):
         
     referenceType = ''
     reference = entry.reference
-    return render_to_response('transportEntry.html', {'section': section, 'subsection': subsection, 'databaseName': db.name, 'entry': entry, 'structure': structure, 'reference': reference, 'referenceType': referenceType, 'transport': transport}, context_instance=RequestContext(request))
+    return render(request, 'transportEntry.html', {'section': section, 'subsection': subsection, 'databaseName': db.name, 'entry': entry, 'structure': structure, 'reference': reference, 'referenceType': referenceType, 'transport': transport})
 
 def transportData(request, adjlist):
     """
@@ -265,7 +265,7 @@ def transportData(request, adjlist):
             entry = Entry(data=data)
         elif library in database.transport.libraries.values():
             source = library.label
-            href = reverse(transportEntry, kwargs={'section': 'libraries', 'subsection': library.label, 'index': entry.index})
+            href = reverse('database:transport-entry', kwargs={'section': 'libraries', 'subsection': library.label, 'index': entry.index})
         transportDataList.append((
             entry,
             data,
@@ -276,7 +276,7 @@ def transportData(request, adjlist):
     # Get the structure of the item we are viewing
     structure = getStructureInfo(molecule)
 
-    return render_to_response('transportData.html', {'molecule': molecule, 'structure': structure, 'transportDataList': transportDataList, 'symmetryNumber': symmetryNumber}, context_instance=RequestContext(request))
+    return render(request, 'transportData.html', {'molecule': molecule, 'structure': structure, 'transportDataList': transportDataList, 'symmetryNumber': symmetryNumber})
 
 #################################################################################################################################################
 
@@ -321,7 +321,7 @@ def solvation(request, section='', subsection=''):
                 
             entries.append((entry.index,entry.label,structure,dataFormat))
 
-        return render_to_response('solvationTable.html', {'section': section, 'subsection': subsection, 'databaseName': db.name, 'entries': entries}, context_instance=RequestContext(request))
+        return render(request, 'solvationTable.html', {'section': section, 'subsection': subsection, 'databaseName': db.name, 'entries': entries})
 
     else:
         # No subsection was specified, so render an outline of the solvation
@@ -332,7 +332,7 @@ def solvation(request, section='', subsection=''):
         solvationLibraries.sort()
         solvationGroups = [(label, groups) for label, groups in database.solvation.groups.iteritems()]
         solvationGroups.sort()
-        return render_to_response('solvation.html', {'section': section, 'subsection': subsection, 'solvationLibraries': solvationLibraries, 'solvationGroups': solvationGroups}, context_instance=RequestContext(request))
+        return render(request, 'solvation.html', {'section': section, 'subsection': subsection, 'solvationLibraries': solvationLibraries, 'solvationGroups': solvationGroups})
     
 def solvationEntry(request, section, subsection, index):
     """
@@ -360,7 +360,7 @@ def solvationEntry(request, section, subsection, index):
             index = min(entry.index for entry in db.entries.values() if entry.index > 0)
         else:
             index = max(entry.index for entry in db.entries.values() if entry.index > 0)
-        return HttpResponseRedirect(reverse(solvationEntry,
+        return HttpResponseRedirect(reverse('database:solvation-entry',
                                             kwargs={'section': section,
                                                     'subsection': subsection,
                                                     'index': index,
@@ -379,7 +379,7 @@ def solvationEntry(request, section, subsection, index):
         
     referenceType = ''
     reference = entry.reference
-    return render_to_response('solvationEntry.html', {'section': section, 'subsection': subsection, 'databaseName': db.name, 'entry': entry, 'structure': structure, 'reference': reference, 'referenceType': referenceType, 'solvation': solvation}, context_instance=RequestContext(request))
+    return render(request, 'solvationEntry.html', {'section': section, 'subsection': subsection, 'databaseName': db.name, 'entry': entry, 'structure': structure, 'reference': reference, 'referenceType': referenceType, 'solvation': solvation})
 
 def solvationData(request, solute_adjlist, solvent=''):
     """
@@ -425,7 +425,7 @@ def solvationData(request, solute_adjlist, solvent=''):
     # Get the structure of the item we are viewing
     structure = getStructureInfo(molecule)
 
-    return render_to_response('solvationData.html', {'molecule': molecule, 'structure': structure, 'solvationDataList': solvationDataList, 'solventDataInfo': solventDataInfo}, context_instance=RequestContext(request))
+    return render(request, 'solvationData.html', {'molecule': molecule, 'structure': structure, 'solvationDataList': solvationDataList, 'solventDataInfo': solventDataInfo})
 
 
 #################################################################################################################################################
@@ -464,7 +464,7 @@ def statmech(request, section='', subsection=''):
                 
             entries.append((entry.index,entry.label,structure,dataFormat))
 
-        return render_to_response('statmechTable.html', {'section': section, 'subsection': subsection, 'databaseName': db.name, 'entries': entries}, context_instance=RequestContext(request))
+        return render(request, 'statmechTable.html', {'section': section, 'subsection': subsection, 'databaseName': db.name, 'entries': entries})
 
     else:
         # No subsection was specified, so render an outline of the statmech
@@ -475,7 +475,7 @@ def statmech(request, section='', subsection=''):
         statmechLibraries.sort()
         statmechGroups = [name for name in database.statmech.groups.iteritems()]
         statmechGroups.sort()
-        return render_to_response('statmech.html', {'section': section, 'subsection': subsection, 'statmechDepository': statmechDepository, 'statmechLibraries': statmechLibraries, 'statmechGroups': statmechGroups}, context_instance=RequestContext(request))
+        return render(request, 'statmech.html', {'section': section, 'subsection': subsection, 'statmechDepository': statmechDepository, 'statmechLibraries': statmechLibraries, 'statmechGroups': statmechGroups})
     
 def statmechEntry(request, section, subsection, index):
     """
@@ -503,7 +503,7 @@ def statmechEntry(request, section, subsection, index):
             index = min(entry.index for entry in db.entries.values() if entry.index > 0)
         else:
             index = max(entry.index for entry in db.entries.values() if entry.index > 0)
-        return HttpResponseRedirect(reverse(statmechEntry,
+        return HttpResponseRedirect(reverse('database:statmech-entry',
                                             kwargs={'section': section,
                                                     'subsection': subsection,
                                                     'index': index,
@@ -522,7 +522,7 @@ def statmechEntry(request, section, subsection, index):
         
     referenceType = ''
     reference = entry.reference
-    return render_to_response('statmechEntry.html', {'section': section, 'subsection': subsection, 'databaseName': db.name, 'entry': entry, 'structure': structure, 'reference': reference, 'referenceType': referenceType, 'statmech': statmech}, context_instance=RequestContext(request))
+    return render(request, 'statmechEntry.html', {'section': section, 'subsection': subsection, 'databaseName': db.name, 'entry': entry, 'structure': structure, 'reference': reference, 'referenceType': referenceType, 'statmech': statmech})
 
 def statmechData(request, adjlist):
     """
@@ -542,13 +542,13 @@ def statmechData(request, adjlist):
     symmetryNumber = species.getSymmetryNumber()
     statmechDataList = []   
     source = 'Solute Descriptors'
-    href = reverse(statmechEntry, kwargs={'section': 'libraries', 'subsection': source, 'index': 1})
+    href = reverse('database:statmech-entry', kwargs={'section': 'libraries', 'subsection': source, 'index': 1})
     statmechDataList.append((1, database.statmech.getSolventData(species.label), source, href))
     
     # Get the structure of the item we are viewing
     structure = getStructureInfo(molecule)
 
-    return render_to_response('statmechData.html', {'molecule': molecule, 'structure': structure, 'statmechDataList': statmechDataList, 'symmetryNumber': symmetryNumber}, context_instance=RequestContext(request))
+    return render(request, 'statmechData.html', {'molecule': molecule, 'structure': structure, 'statmechDataList': statmechDataList, 'symmetryNumber': symmetryNumber})
 
 #################################################################################################################################################
 
@@ -597,7 +597,7 @@ def thermo(request, section='', subsection=''):
                 
             entries.append((entry.index,entry.label,structure,dataFormat))
 
-        return render_to_response('thermoTable.html', {'section': section, 'subsection': subsection, 'databaseName': db.name, 'entries': entries}, context_instance=RequestContext(request))
+        return render(request, 'thermoTable.html', {'section': section, 'subsection': subsection, 'databaseName': db.name, 'entries': entries})
 
     else:
         # No subsection was specified, so render an outline of the thermo
@@ -608,7 +608,7 @@ def thermo(request, section='', subsection=''):
         #If they weren't already sorted in our preferred order, we'd call thermoLibraries.sort()
         thermoGroups = [(label, groups) for label, groups in database.thermo.groups.iteritems()]
         thermoGroups.sort()
-        return render_to_response('thermo.html', {'section': section, 'subsection': subsection, 'thermoDepository': thermoDepository, 'thermoLibraries': thermoLibraries, 'thermoGroups': thermoGroups}, context_instance=RequestContext(request))
+        return render(request, 'thermo.html', {'section': section, 'subsection': subsection, 'thermoDepository': thermoDepository, 'thermoLibraries': thermoLibraries, 'thermoGroups': thermoGroups})
 
 def thermoEntry(request, section, subsection, index):
     """
@@ -637,7 +637,7 @@ def thermoEntry(request, section, subsection, index):
             index = min(entry.index for entry in db.entries.values() if entry.index > 0)
         else:
             index = max(entry.index for entry in db.entries.values() if entry.index > 0)
-        return HttpResponseRedirect(reverse(thermoEntry,
+        return HttpResponseRedirect(reverse('database:thermo-entry',
                                             kwargs={'section': section,
                                                     'subsection': subsection,
                                                     'index': index,
@@ -673,7 +673,7 @@ def thermoEntry(request, section, subsection, index):
         
     referenceType = ''
     reference = entry.reference
-    return render_to_response('thermoEntry.html', {'section': section, 'subsection': subsection, 'databaseName': db.name, 'entry': entry, 'structure': structure, 'reference': reference, 'referenceType': referenceType, 'thermo': thermo, 'nasa_string':nasa_string}, context_instance=RequestContext(request))
+    return render(request, 'thermoEntry.html', {'section': section, 'subsection': subsection, 'databaseName': db.name, 'entry': entry, 'structure': structure, 'reference': reference, 'referenceType': referenceType, 'thermo': thermo, 'nasa_string':nasa_string})
 
 
 def thermoData(request, adjlist):
@@ -710,10 +710,10 @@ def thermoData(request, adjlist):
             entry = Entry(data=data)
         elif library in database.thermo.depository.values():
             source = 'Depository'
-            href = reverse(thermoEntry, kwargs={'section': 'depository', 'subsection': library.label, 'index': entry.index})
+            href = reverse('database:thermo-entry', kwargs={'section': 'depository', 'subsection': library.label, 'index': entry.index})
         elif library in database.thermo.libraries.values():
             source = library.name
-            href = reverse(thermoEntry, kwargs={'section': 'libraries', 'subsection': library.label, 'index': entry.index})
+            href = reverse('database:thermo-entry', kwargs={'section': 'libraries', 'subsection': library.label, 'index': entry.index})
         thermoDataList.append((
             entry,
             data,
@@ -725,7 +725,7 @@ def thermoData(request, adjlist):
     # Get the structure of the item we are viewing
     structure = getStructureInfo(molecule)
 
-    return render_to_response('thermoData.html', {'molecule': molecule, 'structure': structure, 'thermoDataList': thermoDataList, 'symmetryNumber': symmetryNumber, 'plotWidth': 500, 'plotHeight': 400 + 15 * len(thermoDataList)}, context_instance=RequestContext(request))
+    return render(request, 'thermoData.html', {'molecule': molecule, 'structure': structure, 'thermoDataList': thermoDataList, 'symmetryNumber': symmetryNumber, 'plotWidth': 500, 'plotHeight': 400 + 15 * len(thermoDataList)})
 
 ################################################################################
 
@@ -750,7 +750,7 @@ def getKineticsTreeHTML(database, section, subsection, entries):
     html = ''
     for entry in entries:
         # Write current node
-        url = reverse(kineticsEntry, kwargs={'section': section, 'subsection': subsection, 'index': entry.index})
+        url = reverse('database:kinetics-entry', kwargs={'section': section, 'subsection': subsection, 'index': entry.index})
         html += '<li class="kineticsEntry">\n'
         html += '<div class="kineticsLabel">'
         if len(entry.children) > 0:
@@ -1275,7 +1275,7 @@ def kinetics(request, section='', subsection=''):
 
             entries.append(entry)
             
-        return render_to_response('kineticsTable.html', {'section': section, 'subsection': subsection, 'databaseName': db.name, 'databaseDesc':db.longDesc,'entries': entries, 'tree': tree, 'isGroupDatabase': isGroupDatabase}, context_instance=RequestContext(request))
+        return render(request, 'kineticsTable.html', {'section': section, 'subsection': subsection, 'databaseName': db.name, 'databaseDesc':db.longDesc,'entries': entries, 'tree': tree, 'isGroupDatabase': isGroupDatabase})
 
     else:
         # No subsection was specified, so render an outline of the kinetics
@@ -1289,7 +1289,7 @@ def kinetics(request, section='', subsection=''):
             family.depositories.append(getUntrainedReactions(family))
         kineticsFamilies = [(label, family) for label, family in database.kinetics.families.iteritems() if subsection in label]
         kineticsFamilies.sort()
-        return render_to_response('kinetics.html', {'section': section, 'subsection': subsection, 'kineticsLibraries': kineticsLibraries, 'kineticsFamilies': kineticsFamilies}, context_instance=RequestContext(request))
+        return render(request, 'kinetics.html', {'section': section, 'subsection': subsection, 'kineticsLibraries': kineticsLibraries, 'kineticsFamilies': kineticsFamilies})
 
 def kineticsUntrained(request, family):
     database.load('kinetics', 'families')
@@ -1308,7 +1308,7 @@ def kineticsUntrained(request, family):
         entry['arrow'] = '&hArr;' if entry0.item.reversible else '&rarr;'
         
         entries.append(entry)
-    return render_to_response('kineticsTable.html', {'section': 'families', 'subsection': family, 'databaseName': '{0}/untrained'.format(family), 'entries': entries, 'tree': None, 'isGroupDatabase': False}, context_instance=RequestContext(request))
+    return render(request, 'kineticsTable.html', {'section': 'families', 'subsection': family, 'databaseName': '{0}/untrained'.format(family), 'entries': entries, 'tree': None, 'isGroupDatabase': False})
 
 def getReactionUrl(reaction, family=None, estimator=None, resonance=True):
     """
@@ -1334,11 +1334,11 @@ def getReactionUrl(reaction, family=None, estimator=None, resonance=True):
         if estimator:
             kwargs['family'] = family
             kwargs['estimator'] = estimator.replace(' ','_')
-            reactionUrl = reverse(kineticsGroupEstimateEntry, kwargs=kwargs)
+            reactionUrl = reverse('database:kinetics-group', kwargs=kwargs)
         else:
             reactionUrl = ''
     else:
-        reactionUrl = reverse(kineticsData, kwargs=kwargs)
+        reactionUrl = reverse('database:kinetics-data', kwargs=kwargs)
     return reactionUrl
     
 
@@ -1379,7 +1379,7 @@ def kineticsEntryNew(request, family, type):
                                   'subsection': subsection,
                                   'index': entry.index,
                                   }
-                        forward_url = reverse(kineticsEntry, kwargs=kwargs)
+                        forward_url = reverse('database:kinetics-entry', kwargs=kwargs)
                         if type == 'training':
                             message = """
                             This reaction is already in the {0} training set.<br> 
@@ -1392,11 +1392,8 @@ def kineticsEntryNew(request, family, type):
                             View or edit it at <a href="{1}">{1}</a>.
                             """.format(subsection, forward_url)
                             title = '- Entry already in {0}.'.format(subsection)
-                        return render_to_response('simple.html',
-                                                  {'title': title,
-                                                   'body': message,
-                                                   },
-                                                  context_instance=RequestContext(request))
+                        return render(request, 'simple.html',
+                                      {'title': title, 'body': message})
 
             if type == 'NIST':
                 squib = new_entry.label
@@ -1405,11 +1402,10 @@ def kineticsEntryNew(request, family, type):
                 if not isinstance(new_entry, Entry):
                     url = 'http://nist.kinetics.gov/kinetics/Detail?id={0}'.format(squib)
                     message = 'Error in grabbing kinetics from <a href="{0}">NIST</a>.<br>{1}'.format(url, new_entry)
-                    return render_to_response('simple.html',
-                                              {'title': 'Error in grabbing kinetics for {0}.'.format(squib),
-                                               'body': message,
-                                               },
-                                              context_instance=RequestContext(request))
+                    return render(request, 'simple.html',
+                                  {'title': 'Error in grabbing kinetics for {0}.'.format(squib),
+                                   'body': message,
+                                   })
                 msg = 'Imported from NIST database at {0}'.format(new_entry.reference.url)
             else:
                 msg = form.cleaned_data['change']
@@ -1430,7 +1426,7 @@ def kineticsEntryNew(request, family, type):
                       'subsection': subsection,
                       'index': new_entry.index,
                       }
-            forward_url = reverse(kineticsEntry, kwargs=kwargs)
+            forward_url = reverse('database:kinetics-entry', kwargs=kwargs)
             
             if False:
                 # Just return the text.
@@ -1457,21 +1453,18 @@ def kineticsEntryNew(request, family, type):
                 <pre>{0}</pre><br>
                 See result at <a href="{1}">{1}</a>.
                 """.format(commit_result, forward_url)
-                return render_to_response('simple.html', { 
-                    'title': '',
-                    'body': message,
-                    },
-                    context_instance=RequestContext(request))
+                return render(request, 'simple.html',
+                              {'title': '', 'body': message})
     else: # not POST
         form = KineticsEntryEditForm()
 
-    return render_to_response('kineticsEntryEdit.html', {'section': 'families',
-                                                        'subsection': subsection,
-                                                        'databaseName': family,
-                                                        'entry': entry,
-                                                        'form': form,
-                                                        },
-                                  context_instance=RequestContext(request))
+    return render(request, 'kineticsEntryEdit.html',
+                  {'section': 'families',
+                   'subsection': subsection,
+                   'databaseName': family,
+                   'entry': entry,
+                   'form': form,
+                   })
 
 
 @login_required
@@ -1523,14 +1516,14 @@ def kineticsEntryEdit(request, section, subsection, index):
                 return HttpResponse(entry_string, content_type="text/plain")
             if False:
                 # Render it as if it were saved.
-                return render_to_response('kineticsEntry.html', {'section': section,
-                                                         'subsection': subsection,
-                                                         'databaseName': db.name,
-                                                         'entry': new_entry,
-                                                         'reference': entry.reference,
-                                                         'kinetics': entry.data,
-                                                         },
-                              context_instance=RequestContext(request))
+                return render(request, 'kineticsEntry.html',
+                              {'section': section,
+                               'subsection': subsection,
+                               'databaseName': db.name,
+                               'entry': new_entry,
+                               'reference': entry.reference,
+                               'kinetics': entry.data,
+                               })
             if True:
                 # save it
                 db.entries[index] = new_entry
@@ -1551,17 +1544,16 @@ def kineticsEntryEdit(request, section, subsection, index):
                        'subsection': subsection,
                        'index': index,
                       }
-                forward_url = reverse(kineticsEntry, kwargs=kwargs)
+                forward_url = reverse('database:kinetics-entry', kwargs=kwargs)
                 message = """
                 Changes saved succesfully:<br>
                 <pre>{0}</pre><br>
                 See result at <a href="{1}">{1}</a>.
                 """.format(commit_result, forward_url)
-                return render_to_response('simple.html', { 
-                    'title': 'Change saved successfully.',
-                    'body': message,
-                    },
-                    context_instance=RequestContext(request))
+                return render(request, 'simple.html',
+                              {'title': 'Change saved successfully.',
+                               'body': message,
+                               })
             
             # redirect
             return HttpResponseRedirect(forward_url)
@@ -1586,13 +1578,13 @@ def kineticsEntryEdit(request, section, subsection, index):
         
         form = KineticsEntryEditForm(initial={'entry':entry_string })
     
-    return render_to_response('kineticsEntryEdit.html', {'section': section,
-                                                        'subsection': subsection,
-                                                        'databaseName': db.name,
-                                                        'entry': entry,
-                                                        'form': form,
-                                                        },
-                                  context_instance=RequestContext(request))
+    return render(request, 'kineticsEntryEdit.html',
+                  {'section': section,
+                   'subsection': subsection,
+                   'databaseName': db.name,
+                   'entry': entry,
+                   'form': form,
+                   })
 
 @login_required
 def thermoEntryNew(request, section, subsection, adjlist):
@@ -1646,7 +1638,7 @@ def thermoEntryNew(request, section, subsection, adjlist):
                       'subsection': subsection,
                       'index': new_entry.index,
                       }
-            forward_url = reverse(thermoEntry, kwargs=kwargs)
+            forward_url = reverse('database:thermo-entry', kwargs=kwargs)
             
             if False:
                 # Just return the text.
@@ -1673,11 +1665,8 @@ def thermoEntryNew(request, section, subsection, adjlist):
                 <pre>{0}</pre><br>
                 See result at <a href="{1}">{1}</a>.
                 """.format(commit_result, forward_url)
-                return render_to_response('simple.html', { 
-                    'title': '',
-                    'body': message,
-                    },
-                    context_instance=RequestContext(request))
+                return render(request, 'simple.html',
+                              {'title': '', 'body': message})
     else: # not POST
         entry_string ="""
 label = "{label}",
@@ -1699,13 +1688,13 @@ longDesc =
 
         form = ThermoEntryEditForm(initial={'entry':entry_string })
 
-    return render_to_response('thermoEntryEdit.html', {'section': section,
-                                                        'subsection': subsection,
-                                                        'databaseName': db.name,
-                                                        'entry': entry,
-                                                        'form': form,
-                                                        },
-                                  context_instance=RequestContext(request))
+    return render(request, 'thermoEntryEdit.html',
+                  {'section': section,
+                   'subsection': subsection,
+                   'databaseName': db.name,
+                   'entry': entry,
+                   'form': form,
+                   })
     
 
 @login_required
@@ -1757,14 +1746,14 @@ def thermoEntryEdit(request, section, subsection, index):
                 return HttpResponse(entry_string, content_type="text/plain")
             if False:
                 # Render it as if it were saved.
-                return render_to_response('thermoEntry.html', {'section': section,
-                                                         'subsection': subsection,
-                                                         'databaseName': db.name,
-                                                         'entry': new_entry,
-                                                         'reference': entry.reference,
-                                                         'kinetics': entry.data,
-                                                         },
-                              context_instance=RequestContext(request))
+                return render(request, 'thermoEntry.html',
+                              {'section': section,
+                               'subsection': subsection,
+                               'databaseName': db.name,
+                               'entry': new_entry,
+                               'reference': entry.reference,
+                               'kinetics': entry.data,
+                               })
             if True:
                 # save it
                 db.entries[index] = new_entry
@@ -1785,17 +1774,16 @@ def thermoEntryEdit(request, section, subsection, index):
                        'subsection': subsection,
                        'index': index,
                       }
-                forward_url = reverse(thermoEntry, kwargs=kwargs)
+                forward_url = reverse('database:thermo-entry', kwargs=kwargs)
                 message = """
                 Changes saved succesfully:<br>
                 <pre>{0}</pre><br>
                 See result at <a href="{1}">{1}</a>.
                 """.format(commit_result, forward_url)
-                return render_to_response('simple.html', { 
-                    'title': 'Change saved successfully.',
-                    'body': message,
-                    },
-                    context_instance=RequestContext(request))
+                return render(request, 'simple.html',
+                              {'title': 'Change saved successfully.',
+                               'body': message,
+                               })
             
             # redirect
             return HttpResponseRedirect(forward_url)
@@ -1820,13 +1808,13 @@ def thermoEntryEdit(request, section, subsection, index):
         
         form = ThermoEntryEditForm(initial={'entry':entry_string })
     
-    return render_to_response('thermoEntryEdit.html', {'section': section,
-                                                        'subsection': subsection,
-                                                        'databaseName': db.name,
-                                                        'entry': entry,
-                                                        'form': form,
-                                                        },
-                                  context_instance=RequestContext(request))
+    return render(request, 'thermoEntryEdit.html',
+                  {'section': section,
+                   'subsection': subsection,
+                   'databaseName': db.name,
+                   'entry': entry,
+                   'form': form,
+                   })
 
 
 def kineticsEntry(request, section, subsection, index):
@@ -1860,7 +1848,7 @@ def kineticsEntry(request, section, subsection, index):
             index = min(entry.index for entry in entries if entry.index > 0)
         else:
             index = max(entry.index for entry in entries if entry.index > 0)
-        return HttpResponseRedirect(reverse(kineticsEntry,
+        return HttpResponseRedirect(reverse('database:kinetics-entry',
                                             kwargs={'section': section,
                                                     'subsection': subsection,
                                                     'index': index,
@@ -1879,15 +1867,15 @@ def kineticsEntry(request, section, subsection, index):
     
     if isinstance(db, KineticsGroups):
         structure = getStructureInfo(entry.item)
-        return render_to_response('kineticsEntry.html', {'section': section,
-                                                         'subsection': subsection,
-                                                         'databaseName': db.name,
-                                                         'entry': entry,
-                                                         'structure': structure,
-                                                         'reference': reference,
-                                                         'referenceType': referenceType,
-                                                         },
-                                  context_instance=RequestContext(request))
+        return render(request, 'kineticsEntry.html',
+                      {'section': section,
+                       'subsection': subsection,
+                       'databaseName': db.name,
+                       'entry': entry,
+                       'structure': structure,
+                       'reference': reference,
+                       'referenceType': referenceType,
+                       })
     else:
         reactants = ' + '.join([getStructureInfo(reactant) for reactant in entry.item.reactants])
         products = ' + '.join([getStructureInfo(reactant) for reactant in entry.item.products])
@@ -1898,17 +1886,18 @@ def kineticsEntry(request, section, subsection, index):
         reactionUrl = getReactionUrl(entry.item)
 
         
-        return render_to_response('kineticsEntry.html', {'section': section,
-                                                        'subsection': subsection,
-                                                        'databaseName': db.name,
-                                                        'entry': entry,
-                                                        'reactants': reactants,
-                                                        'arrow': arrow,
-                                                        'products': products,
-                                                        'reference': reference,
-                                                        'referenceType': referenceType,
-                                                        'reactionUrl': reactionUrl },
-                                  context_instance=RequestContext(request))
+        return render(request, 'kineticsEntry.html',
+                      {'section': section,
+                       'subsection': subsection,
+                       'databaseName': db.name,
+                       'entry': entry,
+                       'reactants': reactants,
+                       'arrow': arrow,
+                       'products': products,
+                       'reference': reference,
+                       'referenceType': referenceType,
+                       'reactionUrl': reactionUrl,
+                       })
 
 
 def kineticsGroupEstimateEntry(request, family, estimator, reactant1, product1, reactant2='', reactant3='', product2='', product3='', resonance=True):
@@ -1981,12 +1970,12 @@ def kineticsGroupEstimateEntry(request, family, estimator, reactant1, product1, 
         if estimator == 'group_additivity':
             reference = rmgpy.data.reference.Reference(
                 url=request.build_absolute_uri(
-                    reverse(kinetics, kwargs={'section': 'families', 'subsection': family + '/groups'})),
+                    reverse('database:kinetics', kwargs={'section': 'families', 'subsection': family + '/groups'})),
             )
         else:
             reference = rmgpy.data.reference.Reference(
                 url=request.build_absolute_uri(
-                    reverse(kinetics, kwargs={'section': 'families', 'subsection': family + '/rules'})),
+                    reverse('database:kinetics', kwargs={'section': 'families', 'subsection': family + '/rules'})),
             )
         referenceType = ''
     else:
@@ -2010,12 +1999,12 @@ def kineticsGroupEstimateEntry(request, family, estimator, reactant1, product1, 
             if estimator == 'group_additivity':
                 reference = rmgpy.data.reference.Reference(
                     url=request.build_absolute_uri(
-                        reverse(kinetics, kwargs={'section': 'families', 'subsection': family + '/groups'})),
+                        reverse('database:kinetics', kwargs={'section': 'families', 'subsection': family + '/groups'})),
                 )
             else:
                 reference = rmgpy.data.reference.Reference(
                     url=request.build_absolute_uri(
-                        reverse(kinetics, kwargs={'section': 'families', 'subsection': family + '/rules'})),
+                        reverse('database:kinetics', kwargs={'section': 'families', 'subsection': family + '/rules'})),
                 )
             referenceType = ''
 
@@ -2026,23 +2015,23 @@ def kineticsGroupEstimateEntry(request, family, estimator, reactant1, product1, 
 
     assert not (entry and entry_list), 'Either `entry` or `entry_list` should have a value, not both.'
 
-    return render_to_response('kineticsEntry.html', {'section': 'families',
-                                                     'subsection': family,
-                                                     'databaseName': family,
-                                                     'reactants': reactants,
-                                                     'arrow': arrow,
-                                                     'products': products,
-                                                     'reference': reference,
-                                                     'referenceType': referenceType,
-                                                     'entry': entry,
-                                                     'entry_list': entry_list,
-                                                     'forward': True,
-                                                     'reactionUrl': reactionUrl,
-                                                     'reaction': reaction0,
-                                                     'plotWidth': 500,
-                                                     'plotHeight': 400 + 15 * len(entry_list),
-                                                     },
-                              context_instance=RequestContext(request))
+    return render(request, 'kineticsEntry.html',
+                  {'section': 'families',
+                   'subsection': family,
+                   'databaseName': family,
+                   'reactants': reactants,
+                   'arrow': arrow,
+                   'products': products,
+                   'reference': reference,
+                   'referenceType': referenceType,
+                   'entry': entry,
+                   'entry_list': entry_list,
+                   'forward': True,
+                   'reactionUrl': reactionUrl,
+                   'reaction': reaction0,
+                   'plotWidth': 500,
+                   'plotHeight': 400 + 15 * len(entry_list),
+                   })
     
 
 def kineticsJavaEntry(request, entry, reactants_fig, products_fig, kineticsParameters, kineticsModel):
@@ -2052,7 +2041,7 @@ def kineticsJavaEntry(request, entry, reactants_fig, products_fig, kineticsParam
     reference = ''
     referenceType = ''
     arrow = '&hArr;'
-    return render_to_response('kineticsEntry.html', {'section': section, 'subsection': subsection, 'databaseName': databaseName, 'entry': entry, 'reactants': reactants_fig, 'arrow': arrow, 'products': products_fig, 'reference': reference, 'referenceType': referenceType, 'kinetics': entry.data}, context_instance=RequestContext(request))
+    return render(request, 'kineticsEntry.html', {'section': section, 'subsection': subsection, 'databaseName': databaseName, 'entry': entry, 'reactants': reactants_fig, 'arrow': arrow, 'products': products_fig, 'reference': reference, 'referenceType': referenceType, 'kinetics': entry.data})
 
 def kineticsSearch(request):
     """
@@ -2084,11 +2073,11 @@ def kineticsSearch(request):
 
             kwargs['resonance'] = form.cleaned_data['resonance']
 
-            return HttpResponseRedirect(reverse(kineticsResults, kwargs=kwargs))
+            return HttpResponseRedirect(reverse('database:kinetics-results', kwargs=kwargs))
     else:
         form = KineticsSearchForm()
 
-    return render_to_response('kineticsSearch.html', {'form': form}, context_instance=RequestContext(request))
+    return render(request, 'kineticsSearch.html', {'form': form})
 
 def kineticsResults(request, reactant1, reactant2='', reactant3='', product1='', product2='', product3='', resonance=True):
     """
@@ -2145,7 +2134,7 @@ def kineticsResults(request, reactant1, reactant2='', reactant3='', product1='',
         else:
             reactionDataList.append([products, arrow, reactants, count, reactionUrl])
         
-    return render_to_response('kineticsResults.html', {'reactionDataList': reactionDataList}, context_instance=RequestContext(request))
+    return render(request, 'kineticsResults.html', {'reactionDataList': reactionDataList})
 
 def kineticsData(request, reactant1, reactant2='', reactant3='', product1='', product2='', product3='', resonance=True):
     """
@@ -2235,11 +2224,11 @@ def kineticsData(request, reactant1, reactant2='', reactant3='', product1='', pr
             if 'untrained' in reaction.depository.name:
                 continue
             source = '%s' % (reaction.depository.name)
-            href = reverse(kineticsEntry, kwargs={'section': 'families', 'subsection': reaction.depository.label, 'index': reaction.entry.index})
+            href = reverse('database:kinetics-entry', kwargs={'section': 'families', 'subsection': reaction.depository.label, 'index': reaction.entry.index})
             entry = reaction.entry
         elif isinstance(reaction, LibraryReaction):
             source = reaction.library.name
-            href = reverse(kineticsEntry, kwargs={'section': 'libraries', 'subsection': reaction.library.label, 'index': reaction.entry.index})
+            href = reverse('database:kinetics-entry', kwargs={'section': 'libraries', 'subsection': reaction.library.label, 'index': reaction.entry.index})
             entry = reaction.entry
         
         forwardKinetics = reaction.kinetics
@@ -2293,18 +2282,18 @@ def kineticsData(request, reactant1, reactant2='', reactant3='', product1='', pr
             pressure = Quantity(rateForm.cleaned_data['pressure'], str(rateForm.cleaned_data['pressure_units'])).value_si
             eval = [temperature, pressure]
 
-    return render_to_response('kineticsData.html', {'kineticsDataList': kineticsDataList,
-                                                    'plotWidth': 500,
-                                                    'plotHeight': 400 + 15 * len(kineticsDataList),
-                                                    'reactantList': reactantList,
-                                                    'productList': productList,
-                                                    'reverseReactionURL':reverseReactionURL,
-                                                    'form':rateForm,
-                                                    'eval':eval,
-                                                    'new_entry_form':new_entry_form,
-                                                    'subsection':family
-                                                    },
-                                             context_instance=RequestContext(request))
+    return render(request, 'kineticsData.html',
+                  {'kineticsDataList': kineticsDataList,
+                   'plotWidth': 500,
+                   'plotHeight': 400 + 15 * len(kineticsDataList),
+                   'reactantList': reactantList,
+                   'productList': productList,
+                   'reverseReactionURL':reverseReactionURL,
+                   'form':rateForm,
+                   'eval':eval,
+                   'new_entry_form':new_entry_form,
+                   'subsection':family
+                   })
 
 def moleculeSearch(request):
     """
@@ -2346,10 +2335,10 @@ def moleculeSearch(request):
 
         if adjlist is not None:
             if 'thermo' in request.POST:
-                return HttpResponseRedirect(reverse(thermoData, kwargs={'adjlist': adjlist}))
+                return HttpResponseRedirect(reverse('database:thermo-data', kwargs={'adjlist': adjlist}))
 
             if 'transport' in request.POST:
-                return HttpResponseRedirect(reverse(transportData, kwargs={'adjlist': adjlist}))
+                return HttpResponseRedirect(reverse('database:transport-data', kwargs={'adjlist': adjlist}))
 
             if 'reset' in request.POST:
                 form = MoleculeSearchForm()
@@ -2362,14 +2351,14 @@ def moleculeSearch(request):
             except Exception:
                 pass
     
-    return render_to_response('moleculeSearch.html',
-                              {'structure_markup': structure_markup,
-                               'molecule': molecule,
-                               'smiles': smiles,
-                               'inchi': inchi,
-                               'form': form,
-                               'oldAdjlist': oldAdjlist},
-                              context_instance=RequestContext(request))
+    return render(request, 'moleculeSearch.html',
+                  {'structure_markup': structure_markup,
+                   'molecule': molecule,
+                   'smiles': smiles,
+                   'inchi': inchi,
+                   'form': form,
+                   'oldAdjlist': oldAdjlist,
+                   })
 
 
 def solvationSearch(request):
@@ -2396,14 +2385,14 @@ def solvationSearch(request):
                     solvent = 'None'
         
             if 'solvation' in request.POST:
-                return HttpResponseRedirect(reverse(solvationData, kwargs={'solute_adjlist': solute_adjlist, 'solvent': solvent}))
+                return HttpResponseRedirect(reverse('database:solvation-data', kwargs={'solute_adjlist': solute_adjlist, 'solvent': solvent}))
                     
             if 'reset' in request.POST:
                 form = SolvationSearchForm()
                 structure_markup = ''
                 molecule = Molecule()
             
-    return render_to_response('solvationSearch.html', {'structure_markup':structure_markup,'molecule':molecule,'form': form}, context_instance=RequestContext(request))
+    return render(request, 'solvationSearch.html', {'structure_markup':structure_markup,'molecule':molecule,'form': form})
     
 def groupDraw(request):
     """
@@ -2431,7 +2420,7 @@ def groupDraw(request):
             structure_markup = ''
             group = Group()
     
-    return render_to_response('groupDraw.html', {'structure_markup':structure_markup,'group':group,'form': form}, context_instance=RequestContext(request))
+    return render(request, 'groupDraw.html', {'structure_markup':structure_markup,'group':group,'form': form})
 
 def EniSearch(request):
     """
@@ -2472,7 +2461,7 @@ def EniSearch(request):
         logK_BA = 0        
         form = EniSearchForm()            
             
-    return render_to_response('EniSearch.html', {'detergentA': detergentA, 'detergentB': detergentB, 'depositA': depositA, 'depositB': depositB, 'logKAB': logK_AB, 'logKBA': logK_BA, 'form': form}, context_instance=RequestContext(request))
+    return render(request, 'EniSearch.html', {'detergentA': detergentA, 'detergentB': detergentB, 'depositA': depositA, 'depositB': depositB, 'logKAB': logK_AB, 'logKBA': logK_BA, 'form': form})
     
 def moleculeEntry(request,adjlist):
     """
@@ -2490,7 +2479,7 @@ def moleculeEntry(request,adjlist):
         oldAdjlist = molecule.toAdjacencyList(removeH=True,oldStyle=True)
     except:
         pass
-    return render_to_response('moleculeEntry.html',{'structure':structure,'molecule':molecule,'oldAdjlist':oldAdjlist}, context_instance=RequestContext(request))
+    return render(request, 'moleculeEntry.html',{'structure':structure,'molecule':molecule,'oldAdjlist':oldAdjlist})
 
 def groupEntry(request,adjlist):
     """
@@ -2502,7 +2491,7 @@ def groupEntry(request,adjlist):
     group = Group().fromAdjacencyList(adjlist)
     structure = getStructureInfo(group)
     
-    return render_to_response('groupEntry.html',{'structure':structure,'group':group}, context_instance=RequestContext(request))
+    return render(request, 'groupEntry.html',{'structure':structure,'group':group})
 
 def json_to_adjlist(request):
     """

--- a/rmgweb/main/templates/login.html
+++ b/rmgweb/main/templates/login.html
@@ -15,13 +15,13 @@
 
 {% block page_body %}
 
-<p>Don't have an account yet? <a href="{% url 'main.views.signup' %}?next={{ request.path }}">Create one now!</a></p>
+<p>Don't have an account yet? <a href="{% url 'signup' %}?next={{ request.path }}">Create one now!</a></p>
 
 {% if form.errors %}
 <p>Your username and password did not match. Please try again.</p>
 {% endif %}
 
-<form method="post" action="{% url 'main.views.login' %}">
+<form method="post" action="{% url 'login' %}">
 {% csrf_token %}
 
 <table>

--- a/rmgweb/main/templates/privacy.html
+++ b/rmgweb/main/templates/privacy.html
@@ -7,7 +7,7 @@
 {% block extrahead %}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'main.views.privacy' %}">Privacy Policy</a></li>
+<li><a href="{% url 'privacy' %}">Privacy Policy</a></li>
 {% endblock %}
 
 {% block sidebar_items %}{% endblock %}
@@ -25,7 +25,7 @@ server logs, or to share the calculated species, reactions, and/or properties
 in public. This is not currently implemented, but may occur in the future.
 </p>
 <p>
-If you <a href="{% url 'main.views.signup' %}?next={{ request.path }}">register an account</a>,
+If you <a href="{% url 'signup' %}?next={{ request.path }}">register an account</a>,
 then it is stored using the standard Django user authentication.
 Your password is probably safe 
 (read <a href="https://docs.djangoproject.com/en/dev/topics/auth/#how-django-stores-passwords">how Django stores passwords</a>)

--- a/rmgweb/main/templates/resources.html
+++ b/rmgweb/main/templates/resources.html
@@ -8,7 +8,7 @@
 {% block extrahead %}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'main.views.resources' %}">Resources</a></li>
+<li><a href="{% url 'resources' %}">Resources</a></li>
 {% endblock %}
 
 {% block sidebar_items %}{% endblock %}

--- a/rmgweb/main/templates/version.html
+++ b/rmgweb/main/templates/version.html
@@ -27,7 +27,7 @@ th, td {
 {% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'main.views.version' %}">Backend Version</a></li>
+<li><a href="{% url 'version' %}">Backend Version</a></li>
 {% endblock %}
 
 {% block sidebar_items %}{% endblock %}

--- a/rmgweb/main/templates/viewProfile.html
+++ b/rmgweb/main/templates/viewProfile.html
@@ -46,7 +46,7 @@
 
 {% if user == user0 %}
 <p>
-   <a href="{% url 'rmgweb.main.views.editProfile' %}" title="Edit profile"><button>Edit Profile</button></a>
+   <a href="{% url 'edit-profile' %}" title="Edit profile"><button>Edit Profile</button></a>
 </p>
 {% endif %}
 
@@ -62,8 +62,8 @@
     </tr>
 {% for network in networks %}
     <tr>
-        <td><a href="{% url 'rmgweb.pdep.views.networkIndex' networkKey=network.pk %}">{{ network.pk|slice:":8" }}</a></td>
-        <td><a href="{% url 'rmgweb.pdep.views.networkIndex' networkKey=network.pk %}">{{ network.title }}</a></td>
+        <td><a href="{% url 'pdep:network-index' networkKey=network.pk %}">{{ network.pk|slice:":8" }}</a></td>
+        <td><a href="{% url 'pdep:network-index' networkKey=network.pk %}">{{ network.title }}</a></td>
         <td style="font-size: 80%; white-space: nowrap;">Last modified on {{ network.getLastModifiedDate }}</td>
     </tr>
 {% endfor %}

--- a/rmgweb/main/templatetags/render_thermo.py
+++ b/rmgweb/main/templatetags/render_thermo.py
@@ -246,7 +246,7 @@ def render_thermo_math(thermo, user=None):
     elif isinstance(thermo, list):
         # The thermo is a link
         index = thermo[1]
-        url = reverse('database.views.thermoEntry', {'section': section, 'subsection': subsection, 'index': index})
+        url = reverse('database:thermo-entry', {'section': section, 'subsection': subsection, 'index': index})
         result += '<table class="thermoEntryData">\n'
         result += '<tr>'
         result += r'    <td class="key">Link:</td>'

--- a/rmgweb/main/tools.py
+++ b/rmgweb/main/tools.py
@@ -56,9 +56,7 @@ def moleculeToInfo(molecule):
     Creates an html rendering which includes molecule structure image but
     also allows you to click on it to enter a molecule info page.
     """
-
-    from rmgweb.database.views import moleculeEntry
-    href = reverse(moleculeEntry, kwargs={'adjlist': molecule.toAdjacencyList()})
+    href = reverse('database:molecule-entry', kwargs={'adjlist': molecule.toAdjacencyList()})
     structureMarkup = getStructureMarkup(molecule)
     markup = '<a href="'+ href + '">' + structureMarkup + '</a>'
     return markup
@@ -89,9 +87,7 @@ def groupToInfo(group):
     Creates an html rendering which includes group structure image but
     also allows you to click on it to enter a group info page.
     """
-
-    from rmgweb.database.views import groupEntry
-    href = reverse(groupEntry, kwargs={'adjlist': group.toAdjacencyList()})
+    href = reverse('database:group-entry', kwargs={'adjlist': group.toAdjacencyList()})
     structureMarkup = getStructureMarkup(group)
     markup = '<a href="'+ href + '">' + structureMarkup + '</a>'
     return markup
@@ -163,12 +159,12 @@ def getStructureMarkup(item):
         # We can draw Molecule objects, so use that instead of an adjacency list
         adjlist = item.toAdjacencyList(removeH=False)
         url = urllib.quote(adjlist)
-        structure = '<img src="{0}" alt="{1}" title="{1}"/>'.format(reverse('rmgweb.main.views.drawMolecule', kwargs={'adjlist': url}), adjlist)
+        structure = '<img src="{0}" alt="{1}" title="{1}"/>'.format(reverse('draw-molecule', kwargs={'adjlist': url}), adjlist)
     elif isinstance(item, Species) and len(item.molecule) > 0:
         # We can draw Species objects, so use that instead of an adjacency list
         adjlist = item.molecule[0].toAdjacencyList(removeH=False)
         url = urllib.quote(adjlist)
-        structure = '<img src="{0}" alt="{1}" title="{1}"/>'.format(reverse('rmgweb.main.views.drawMolecule', kwargs={'adjlist': url}), item.label)
+        structure = '<img src="{0}" alt="{1}" title="{1}"/>'.format(reverse('draw-molecule', kwargs={'adjlist': url}), item.label)
     elif isinstance(item, Species) and len(item.molecule) == 0:
         # We can draw Species objects, so use that instead of an adjacency list
         structure = item.label
@@ -176,7 +172,7 @@ def getStructureMarkup(item):
         # We can draw Group objects, so use that instead of an adjacency list
         adjlist = item.toAdjacencyList()
         url = urllib.quote(adjlist)
-        structure = '<img src="{0}" alt="{1}" title="{1}" />'.format(reverse('rmgweb.main.views.drawGroup', kwargs={'adjlist': url}), adjlist)
+        structure = '<img src="{0}" alt="{1}" title="{1}" />'.format(reverse('draw-group', kwargs={'adjlist': url}), adjlist)
         #structure += '<pre style="font-size:small;" class="adjacancy_list">{0}</pre>'.format(adjlist)
     elif isinstance(item, str) or isinstance(item, unicode):
         structure = item

--- a/rmgweb/main/views.py
+++ b/rmgweb/main/views.py
@@ -28,7 +28,7 @@
 #                                                                             #
 ###############################################################################
 
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import RequestContext, loader
 from django.http import HttpResponse, HttpResponseRedirect, HttpResponseNotFound, HttpResponseServerError
 import django.contrib.auth.views
@@ -49,21 +49,19 @@ def index(request):
     The RMG website homepage.
     """
     from rmgpy import __version__
-    return render_to_response('index.html', {'version': __version__}, context_instance=RequestContext(request))
+    return render(request, 'index.html', {'version': __version__})
 
 def privacy(request):
     """
     The RMG privacy policy.
     """
-    return render_to_response('privacy.html',
-                              {'admins': settings.ADMINS},
-                              context_instance=RequestContext(request))
+    return render(request, 'privacy.html', {'admins': settings.ADMINS})
 
 def version(request):
     """
     Version information for RMG-website, RMG-Py, and RMG-database
     """
-    return render_to_response('version.html', context_instance=RequestContext(request))
+    return render(request, 'version.html')
 
 def resources(request):
     """
@@ -98,9 +96,7 @@ def resources(request):
             title = title.replace('+', ' and ')
             presentations.append((title, date, f))
 
-    return render_to_response('resources.html',
-                              {'presentations': presentations},
-                              context_instance=RequestContext(request))
+    return render(request, 'resources.html', {'presentations': presentations})
 
 def login(request):
     """
@@ -142,7 +138,7 @@ def signup(request):
         profileForm = UserProfileSignupForm(error_class=DivErrorList)
         passwordForm = PasswordCreateForm(error_class=DivErrorList)
         
-    return render_to_response('signup.html', {'userForm': userForm, 'profileForm': profileForm, 'passwordForm': passwordForm}, context_instance=RequestContext(request))
+    return render(request, 'signup.html', {'userForm': userForm, 'profileForm': profileForm, 'passwordForm': passwordForm})
 
 def viewProfile(request, username):
     """
@@ -154,7 +150,7 @@ def viewProfile(request, username):
     user0 = User.objects.get(username=username)
     userProfile = user0.userprofile
     networks = Network.objects.filter(user=user0)
-    return render_to_response('viewProfile.html', {'user0': user0, 'userProfile': userProfile, 'networks': networks}, context_instance=RequestContext(request))
+    return render(request, 'viewProfile.html', {'user0': user0, 'userProfile': userProfile, 'networks': networks})
 
 @login_required
 def editProfile(request):
@@ -170,13 +166,13 @@ def editProfile(request):
             userForm.save()
             profileForm.save()
             passwordForm.save()
-            return HttpResponseRedirect(reverse(viewProfile, kwargs={'username': request.user.username})) # Redirect after POST
+            return HttpResponseRedirect(reverse('view-profile', kwargs={'username': request.user.username})) # Redirect after POST
     else:
         userForm = UserForm(instance=request.user, error_class=DivErrorList)
         profileForm = UserProfileForm(instance=user_profile, error_class=DivErrorList)
         passwordForm = PasswordChangeForm(error_class=DivErrorList)
         
-    return render_to_response('editProfile.html', {'userForm': userForm, 'profileForm': profileForm, 'passwordForm': passwordForm}, context_instance=RequestContext(request))
+    return render(request, 'editProfile.html', {'userForm': userForm, 'profileForm': profileForm, 'passwordForm': passwordForm})
 
 def getAdjacencyList(request, identifier):
     """

--- a/rmgweb/pdep/templates/networkEditor.html
+++ b/rmgweb/pdep/templates/networkEditor.html
@@ -6,9 +6,9 @@
 {% block title %}Edit Input File{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'pdep.views.index' %}">Pressure Dependent Networks</a></li>
-<li><a href="{% url 'pdep.views.networkIndex' networkKey=networkKey%}">Network {{ networkKey }}</a></li>
-<li><a href="{% url 'pdep.views.networkEditor' networkKey=networkKey%}">Edit</a></li>
+<li><a href="{% url 'pdep:index' %}">Pressure Dependent Networks</a></li>
+<li><a href="{% url 'pdep:network-index' networkKey=networkKey%}">Network {{ networkKey }}</a></li>
+<li><a href="{% url 'pdep:network-editor' networkKey=networkKey%}">Edit</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/pdep/templates/networkIndex.html
+++ b/rmgweb/pdep/templates/networkIndex.html
@@ -5,8 +5,8 @@
 {% block title %}{{ network.title }}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'pdep.views.index' %}">Pressure Dependent Networks</a></li>
-<li><a href="{% url 'pdep.views.networkIndex' networkKey=networkKey%}">{{ network.title }}</a></li>
+<li><a href="{% url 'pdep:index' %}">Pressure Dependent Networks</a></li>
+<li><a href="{% url 'pdep:network-index' networkKey=networkKey%}">{{ network.title }}</a></li>
 {% endblock %}
 
 {% block sidebar_items %}
@@ -22,8 +22,8 @@
 <div class="messagebox">
 <p class="bigmessage">No input has been provided for this network.</p>
 <p>You can add input by using
-<a href="{% url 'pdep.views.networkEditor' networkKey=networkKey%}">the editor</a>, or by
-<a href="{% url 'pdep.views.networkUpload' networkKey=networkKey%}">uploading a file</a>.
+<a href="{% url 'pdep:network-editor' networkKey=networkKey%}">the editor</a>, or by
+<a href="{% url 'pdep:network-upload' networkKey=networkKey%}">uploading a file</a>.
 </p>
 </div>
 
@@ -33,7 +33,7 @@
 {% if network.surfaceFilePNGExists %}
 {% if network.surfaceFilePNGOutOfDate %}
 <div class="warning">
-<strong>Warning:</strong> Your potential energy surface may be out of date. You may want to <a href="{% url 'pdep.views.networkDrawPNG' networkKey=networkKey %}">redraw it</a>.
+<strong>Warning:</strong> Your potential energy surface may be out of date. You may want to <a href="{% url 'pdep:network-draw-png' networkKey=networkKey %}">redraw it</a>.
 </div>
 {% endif %}
 <p style="text-align: center;">
@@ -42,7 +42,7 @@
 {% else %}
 <div class="messagebox">
 <p class="bigmessage">No potential energy surface has been drawn for this network.</p>
-<p>To visualize your potential energy surface, <a href="{% url 'pdep.views.networkDrawPNG' networkKey=networkKey %}">click here</a>.
+<p>To visualize your potential energy surface, <a href="{% url 'pdep:network-draw-png' networkKey=networkKey %}">click here</a>.
 </p>
 </div>
 {% endif %}
@@ -61,7 +61,7 @@
 </tr>
 {% for label, structure, type, collision, states, thermo in speciesList %}
 <tr>
-    <td><a href="{% url 'pdep.views.networkSpecies' networkKey=networkKey species=label %}">{{ label }}</a></td>
+    <td><a href="{% url 'pdep:network-species' networkKey=networkKey species=label %}">{{ label }}</a></td>
     <td>{{ structure|safe }}</td>
     <td>{{ type }}</td>
     <td>{{ collision }}</td>
@@ -83,7 +83,7 @@
 </tr>
 {% for reactants, arrow, products, states, kinetics in pathReactionList %}
 <tr>
-    <td><a href="{% url 'pdep.views.networkPathReaction' networkKey=networkKey reaction=forloop.counter %}">{{ forloop.counter }}.</a></td>
+    <td><a href="{% url 'pdep:network-path-reaction' networkKey=networkKey reaction=forloop.counter %}">{{ forloop.counter }}.</a></td>
     <td class="reactants">{{ reactants|safe }}</td>
     <td class="reactionArrow">{{ arrow|safe }}</td>
     <td class="products">{{ products|safe }}</td>
@@ -107,7 +107,7 @@
 </tr>
 {% for reactants, arrow, products, kinetics in netReactionList %}
 <tr>
-    <td><a href="{% url 'pdep.views.networkNetReaction' networkKey=networkKey reaction=forloop.counter %}">{{ forloop.counter }}.</a></td>
+    <td><a href="{% url 'pdep:network-net-reaction' networkKey=networkKey reaction=forloop.counter %}">{{ forloop.counter }}.</a></td>
     <td class="reactants">{{ reactants|safe }}</td>
     <td class="reactionArrow">{{ arrow|safe }}</td>
     <td class="products">{{ products|safe }}</td>

--- a/rmgweb/pdep/templates/networkNetReaction.html
+++ b/rmgweb/pdep/templates/networkNetReaction.html
@@ -7,9 +7,9 @@
 {% block title %}Net Reaction #{{ index }} - {{ network.title }}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'pdep.views.index' %}">Pressure Dependent Networks</a></li>
-<li><a href="{% url 'pdep.views.networkIndex' networkKey=networkKey%}">{{ network.title }}</a></li>
-<li><a href="{% url 'pdep.views.networkNetReaction' reaction=index networkKey=networkKey%}">Net Reaction #{{ index }}</a></li>
+<li><a href="{% url 'pdep:index' %}">Pressure Dependent Networks</a></li>
+<li><a href="{% url 'pdep:network-index' networkKey=networkKey%}">{{ network.title }}</a></li>
+<li><a href="{% url 'pdep:network-net-reaction' reaction=index networkKey=networkKey%}">Net Reaction #{{ index }}</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/pdep/templates/networkPathReaction.html
+++ b/rmgweb/pdep/templates/networkPathReaction.html
@@ -8,9 +8,9 @@
 {% block title %}Path Reaction #{{ index }} - {{ network.title }}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'pdep.views.index' %}">Pressure Dependent Networks</a></li>
-<li><a href="{% url 'pdep.views.networkIndex' networkKey=networkKey%}">{{ network.title }}</a></li>
-<li><a href="{% url 'pdep.views.networkPathReaction' reaction=index networkKey=networkKey%}">Path Reaction #{{ index }}</a></li>
+<li><a href="{% url 'pdep:index' %}">Pressure Dependent Networks</a></li>
+<li><a href="{% url 'pdep:network-index' networkKey=networkKey%}">{{ network.title }}</a></li>
+<li><a href="{% url 'pdep:network-path-reaction' reaction=index networkKey=networkKey%}">Path Reaction #{{ index }}</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/pdep/templates/networkPlotKinetics.html
+++ b/rmgweb/pdep/templates/networkPlotKinetics.html
@@ -6,9 +6,9 @@
 {% block title %}Plot Kinetics - {{ network.title }}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'pdep.views.index' %}">Pressure Dependent Networks</a></li>
-<li><a href="{% url 'pdep.views.networkIndex' networkKey=networkKey%}">{{ network.title }}</a></li>
-<li><a href="{% url 'pdep.views.networkPlotKinetics' networkKey=networkKey%}">Plot Kinetics</a></li>
+<li><a href="{% url 'pdep:index' %}">Pressure Dependent Networks</a></li>
+<li><a href="{% url 'pdep:network-index' networkKey=networkKey%}">{{ network.title }}</a></li>
+<li><a href="{% url 'pdep:network-plot-kinetics' networkKey=networkKey%}">Plot Kinetics</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/pdep/templates/networkPlotMicro.html
+++ b/rmgweb/pdep/templates/networkPlotMicro.html
@@ -6,9 +6,9 @@
 {% block title %}Plot Microcanonical Data - {{ network.title }}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'pdep.views.index' %}">Pressure Dependent Networks</a></li>
-<li><a href="{% url 'pdep.views.networkIndex' networkKey=networkKey%}">{{ network.title }}</a></li>
-<li><a href="{% url 'pdep.views.networkPlotMicro' networkKey=networkKey%}">Plot Microcanonical Data</a></li>
+<li><a href="{% url 'pdep:index' %}">Pressure Dependent Networks</a></li>
+<li><a href="{% url 'pdep:network-index' networkKey=networkKey%}">{{ network.title }}</a></li>
+<li><a href="{% url 'pdep:network-plot-micro' networkKey=networkKey%}">Plot Microcanonical Data</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/pdep/templates/networkSidebar.html
+++ b/rmgweb/pdep/templates/networkSidebar.html
@@ -2,11 +2,11 @@
 <div class="menuitem" style="border-top: 2px solid #FFFFFF;">
     <div class="menutitle">Input</div>
     {% if not network.inputFileExists %}
-    <div><a href="{% url 'pdep.views.networkEditor' networkKey=networkKey%}">Create an input file manually</a></div>
-    <div><a href="{% url 'pdep.views.networkUpload' networkKey=networkKey%}">Upload an input file</a></div>
+    <div><a href="{% url 'pdep:network-editor' networkKey=networkKey%}">Create an input file manually</a></div>
+    <div><a href="{% url 'pdep:network-upload' networkKey=networkKey%}">Upload an input file</a></div>
     {% else %}
-    <div><a href="{% url 'pdep.views.networkEditor' networkKey=networkKey%}">Edit an input file manually</a></div>
-    <div><a href="{% url 'pdep.views.networkUpload' networkKey=networkKey%}">Upload a replacement input file</a></div>
+    <div><a href="{% url 'pdep:network-editor' networkKey=networkKey%}">Edit an input file manually</a></div>
+    <div><a href="{% url 'pdep:network-upload' networkKey=networkKey%}">Upload a replacement input file</a></div>
     {% endif %}
 </div>
 
@@ -15,19 +15,19 @@
 <div class="menuitem">
     <div class="menutitle">Output</div>
     {% if not network.outputFileExists %}
-    <div><a href="{% url 'pdep.views.networkRun' networkKey=networkKey%}">Run Pressure Dependent Networks</a></div>
+    <div><a href="{% url 'pdep:network-run' networkKey=networkKey%}">Run Pressure Dependent Networks</a></div>
     {% else %}
-    <div><a href="{% url 'pdep.views.networkPlotMicro' networkKey=networkKey%}">Plot k(E) and &rho;(E) values</a></div>
-    <!-- <div><a href="{% url 'pdep.views.networkPlotKinetics' networkKey=networkKey%}">Plot k(T,P) values</a></div>  -->
-    <div><a href="{% url 'pdep.views.networkRun' networkKey=networkKey%}">Rerun Pressure Dependent Networks</a></div>
+    <div><a href="{% url 'pdep:network-plot-micro' networkKey=networkKey%}">Plot k(E) and &rho;(E) values</a></div>
+    <!-- <div><a href="{% url 'pdep:network-plot-kinetics' networkKey=networkKey%}">Plot k(T,P) values</a></div>  -->
+    <div><a href="{% url 'pdep:network-run' networkKey=networkKey%}">Rerun Pressure Dependent Networks</a></div>
     {% endif %}
 </div>
 
 <div class="menuitem">
     <div class="menutitle">Potential Energy Surface</div>
-    <div><a href="{% url 'pdep.views.networkDrawPNG' networkKey=networkKey %}">{% if network.surfaceFilePNGExists %}Redraw{% else %}Draw{% endif %} surface as PNG</a></div>
-    <div><a href="{% url 'pdep.views.networkDrawPDF' networkKey=networkKey %}">{% if network.surfaceFilePDFExists %}Redraw{% else %}Draw{% endif %} surface as PDF</a></div>
-    <div><a href="{% url 'pdep.views.networkDrawSVG' networkKey=networkKey %}">{% if network.surfaceFileSVGExists %}Redraw{% else %}Draw{% endif %} surface as SVG</a></div>
+    <div><a href="{% url 'pdep:network-draw-png' networkKey=networkKey %}">{% if network.surfaceFilePNGExists %}Redraw{% else %}Draw{% endif %} surface as PNG</a></div>
+    <div><a href="{% url 'pdep:network-draw-pdf' networkKey=networkKey %}">{% if network.surfaceFilePDFExists %}Redraw{% else %}Draw{% endif %} surface as PDF</a></div>
+    <div><a href="{% url 'pdep:network-draw-svg' networkKey=networkKey %}">{% if network.surfaceFileSVGExists %}Redraw{% else %}Draw{% endif %} surface as SVG</a></div>
 </div>
 
 {% endif %}

--- a/rmgweb/pdep/templates/networkSpecies.html
+++ b/rmgweb/pdep/templates/networkSpecies.html
@@ -10,9 +10,9 @@
 {% block title %}{{ label }} - {{ network.title }}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'pdep.views.index' %}">Pressure Dependent Networks</a></li>
-<li><a href="{% url 'pdep.views.networkIndex' networkKey=networkKey%}">{{ network.title }}</a></li>
-<li><a href="{% url 'pdep.views.networkSpecies' species=label networkKey=networkKey%}">{{ label }}</a></li>
+<li><a href="{% url 'pdep:index' %}">Pressure Dependent Networks</a></li>
+<li><a href="{% url 'pdep:network-index' networkKey=networkKey%}">{{ network.title }}</a></li>
+<li><a href="{% url 'pdep:network-species' species=label networkKey=networkKey%}">{{ label }}</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/pdep/templates/networkUpload.html
+++ b/rmgweb/pdep/templates/networkUpload.html
@@ -7,9 +7,9 @@
 {% block title %}Upload Input File{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'pdep.views.index' %}">Pressure Dependent Networks</a></li>
-<li><a href="{% url 'pdep.views.networkIndex' networkKey=networkKey%}">Network {{ networkKey }}</a></li>
-<li><a href="{% url 'pdep.views.networkUpload' networkKey=networkKey%}">Upload</a></li>
+<li><a href="{% url 'pdep:index' %}">Pressure Dependent Networks</a></li>
+<li><a href="{% url 'pdep:network-index' networkKey=networkKey%}">Network {{ networkKey }}</a></li>
+<li><a href="{% url 'pdep:network-upload' networkKey=networkKey%}">Upload</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/pdep/templates/pdep.html
+++ b/rmgweb/pdep/templates/pdep.html
@@ -5,7 +5,7 @@
 {% block title %}RMG: Pressure Dependent Networks{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'pdep.views.index' %}">Pressure Dependent Networks</a></li>
+<li><a href="{% url 'pdep:index' %}">Pressure Dependent Networks</a></li>
 {% endblock %}
 
 {% block sidebar_items %}
@@ -23,7 +23,7 @@ The approach is to first generate a detailed model of the reaction network using
  
 You can use it right from your web browser by following the link below:</p>
 
-<p class="biglink"><a href="{% url 'pdep.views.start' %}">Create New Pressure Dependent Network</a></p>
+<p class="biglink"><a href="{% url 'pdep:start' %}">Create New Pressure Dependent Network</a></p>
 
 {% if user.is_authenticated %}
 <h2>Your previous reaction networks</h2>
@@ -36,16 +36,16 @@ You can use it right from your web browser by following the link below:</p>
     </tr>
 {% for network in networks %}
     <tr>
-        <td><a href="{% url 'rmgweb.pdep.views.networkIndex' networkKey=network.pk %}">{{ network.pk|slice:":8" }}</a></td>
-        <td><a href="{% url 'rmgweb.pdep.views.networkIndex' networkKey=network.pk %}">{{ network.title }}</a></td>
+        <td><a href="{% url 'pdep:network-index' networkKey=network.pk %}">{{ network.pk|slice:":8" }}</a></td>
+        <td><a href="{% url 'pdep:network-index' networkKey=network.pk %}">{{ network.title }}</a></td>
         <td style="font-size: 80%; white-space: nowrap;">Last modified on {{ network.getLastModifiedDate }}</td>
-        <td><a href="{% url 'rmgweb.pdep.views.networkDelete' networkKey=network.pk %}">Delete this Network</a></td>
+        <td><a href="{% url 'pdep:network-delete' networkKey=network.pk %}">Delete this Network</a></td>
     </tr>
 {% endfor %}
 </table>
 <br/>
 {% else %}
-<a href="{% url 'main.views.login' %}?next={{ request.path }}">Log in</a> to see your previous reaction networks.
+<a href="{% url 'login' %}?next={{ request.path }}">Log in</a> to see your previous reaction networks.
 {% endif %}
 
 

--- a/rmgweb/pdep/urls.py
+++ b/rmgweb/pdep/urls.py
@@ -30,34 +30,37 @@
 
 from django.conf.urls import url, include
 from rmgweb.pdep import views
+
+app_name = 'pdep'
+
 urlpatterns = [
     # Pressure dependence homepage
-    url(r'^$', views.index),
+    url(r'^$', views.index, name='index'),
 
     # URL for beginning a new calculation
-    url(r'^start$', views.start),
+    url(r'^start$', views.start, name='start'),
 
     # URL for the main page of an individual Network
-    url(r'^networks/(?P<networkKey>[^/]+)$', views.networkIndex),
+    url(r'^networks/(?P<networkKey>[^/]+)$', views.networkIndex, name='network-index'),
     
     # URLs for various methods of adding/editing input parameters
-    url(r'^networks/(?P<networkKey>[^/]+)/edit$', views.networkEditor),
-    url(r'^networks/(?P<networkKey>[^/]+)/upload$', views.networkUpload),
+    url(r'^networks/(?P<networkKey>[^/]+)/edit$', views.networkEditor, name='network-editor'),
+    url(r'^networks/(?P<networkKey>[^/]+)/upload$', views.networkUpload, name='network-upload'),
 
     # URLs for generating various output files
-    url(r'^networks/(?P<networkKey>[^/]+)/draw/png$', views.networkDrawPNG),
-    url(r'^networks/(?P<networkKey>[^/]+)/draw/pdf$', views.networkDrawPDF),
-    url(r'^networks/(?P<networkKey>[^/]+)/draw/svg$', views.networkDrawSVG),
-    url(r'^networks/(?P<networkKey>[^/]+)/run$', views.networkRun),
+    url(r'^networks/(?P<networkKey>[^/]+)/draw/png$', views.networkDrawPNG, name='network-draw-png'),
+    url(r'^networks/(?P<networkKey>[^/]+)/draw/pdf$', views.networkDrawPDF, name='network-draw-pdf'),
+    url(r'^networks/(?P<networkKey>[^/]+)/draw/svg$', views.networkDrawSVG, name='network-draw-svg'),
+    url(r'^networks/(?P<networkKey>[^/]+)/run$', views.networkRun, name='network-run'),
     
     # URLs for browsing network information
-    url(r'^networks/(?P<networkKey>[^/]+)/species/(?P<species>[^/]+)$', views.networkSpecies),
-    url(r'^networks/(?P<networkKey>[^/]+)/pathReactions/(?P<reaction>[^/]+)$', views.networkPathReaction),
-    url(r'^networks/(?P<networkKey>[^/]+)/netReactions/(?P<reaction>[^/]+)$', views.networkNetReaction),
-    url(r'^networks/(?P<networkKey>[^/]+)/kinetics$', views.networkPlotKinetics),
-    url(r'^networks/(?P<networkKey>[^/]+)/microdata$', views.networkPlotMicro),
+    url(r'^networks/(?P<networkKey>[^/]+)/species/(?P<species>[^/]+)$', views.networkSpecies, name='network-species'),
+    url(r'^networks/(?P<networkKey>[^/]+)/pathReactions/(?P<reaction>[^/]+)$', views.networkPathReaction, name='network-path-reaction'),
+    url(r'^networks/(?P<networkKey>[^/]+)/netReactions/(?P<reaction>[^/]+)$', views.networkNetReaction, name='network-net-reaction'),
+    url(r'^networks/(?P<networkKey>[^/]+)/kinetics$', views.networkPlotKinetics, name='network-plot-kinetics'),
+    url(r'^networks/(?P<networkKey>[^/]+)/microdata$', views.networkPlotMicro, name='network-plot-micro'),
     
     # Delete a network    
-    url(r'^networks/(?P<networkKey>[^/]+)/delete$', views.networkDelete),
+    url(r'^networks/(?P<networkKey>[^/]+)/delete$', views.networkDelete, name='network-delete'),
     
 ]

--- a/rmgweb/pdep/views.py
+++ b/rmgweb/pdep/views.py
@@ -32,7 +32,7 @@ import os.path
 import time
 import re
 
-from django.shortcuts import render_to_response, get_object_or_404
+from django.shortcuts import render, get_object_or_404
 from django.template import RequestContext
 from django.http import Http404, HttpResponseRedirect
 from django.core.urlresolvers import reverse
@@ -54,7 +54,7 @@ def index(request):
         networks = Network.objects.filter(user=request.user)
     else:
         networks = []
-    return render_to_response('pdep.html', {'networks': networks}, context_instance=RequestContext(request))
+    return render(request, 'pdep.html', {'networks': networks})
 
 @login_required
 def start(request):
@@ -66,7 +66,7 @@ def start(request):
     # Create and save a new Network
     network = Network(title='Untitled Network', user=request.user)
     network.save()
-    return HttpResponseRedirect(reverse(networkIndex,args=(network.pk,)))
+    return HttpResponseRedirect(reverse('pdep:network-index',args=(network.pk,)))
 
 def networkIndex(request, networkKey):
     """
@@ -137,19 +137,15 @@ def networkIndex(request, networkKey):
             kinetics = 'yes' if rxn.kinetics is not None else ''
             netReactionList.append((reactants, arrow, products, kinetics))
     
-    return render_to_response(
-        'networkIndex.html', 
-        {
-            'network': networkModel, 
-            'networkKey': networkKey, 
-            'speciesList': speciesList, 
-            'pathReactionList': pathReactionList, 
-            'netReactionList': netReactionList, 
-            'filesize': filesize, 
-            'modificationTime': modificationTime,
-        }, 
-        context_instance=RequestContext(request),
-    )
+    return render(request, 'networkIndex.html',
+                  {'network': networkModel,
+                   'networkKey': networkKey,
+                   'speciesList': speciesList,
+                   'pathReactionList': pathReactionList,
+                   'netReactionList': netReactionList,
+                   'filesize': filesize,
+                   'modificationTime': modificationTime,
+                   })
 
 def networkEditor(request, networkKey):
     """
@@ -165,13 +161,13 @@ def networkEditor(request, networkKey):
             # Save the form
             network = form.save()
             # Go back to the network's main page
-            return HttpResponseRedirect(reverse(networkIndex,args=(network.pk,)))
+            return HttpResponseRedirect(reverse('pdep:network-index',args=(network.pk,)))
     else:
         # Load the text from the input file into the inputText field
         network.loadInputText()
         # Create the form
         form = EditNetworkForm(instance=network)
-    return render_to_response('networkEditor.html', {'network': network, 'networkKey': networkKey, 'form': form}, context_instance=RequestContext(request))
+    return render(request, 'networkEditor.html', {'network': network, 'networkKey': networkKey, 'form': form})
 
 def networkDelete(request, networkKey):
     """
@@ -179,7 +175,7 @@ def networkDelete(request, networkKey):
     """
     network = get_object_or_404(Network, pk=networkKey)
     network.delete()
-    return HttpResponseRedirect(reverse(index))
+    return HttpResponseRedirect(reverse('pdep:index'))
 
 
 def networkUpload(request, networkKey):
@@ -198,11 +194,11 @@ def networkUpload(request, networkKey):
             # Load the text from the input file into the inputText field
             network.loadInputText()
             # Go back to the network's main page
-            return HttpResponseRedirect(reverse(networkIndex,args=(network.pk,)))
+            return HttpResponseRedirect(reverse('pdep:network-index',args=(network.pk,)))
     else:
         # Create the form
         form = UploadNetworkForm(instance=network)
-    return render_to_response('networkUpload.html', {'network': network, 'networkKey': networkKey, 'form': form}, context_instance=RequestContext(request))
+    return render(request, 'networkUpload.html', {'network': network, 'networkKey': networkKey, 'form': form})
 
 def networkDrawPNG(request, networkKey):
     """
@@ -221,7 +217,7 @@ def networkDrawPNG(request, networkKey):
     )
     
     # Go back to the network's main page
-    return HttpResponseRedirect(reverse(networkIndex,args=(networkModel.pk,)))
+    return HttpResponseRedirect(reverse('pdep:network-index',args=(networkModel.pk,)))
 
 def networkDrawPDF(request, networkKey):
     """
@@ -240,7 +236,7 @@ def networkDrawPDF(request, networkKey):
     )
     
     # Go back to the network's main page
-    return HttpResponseRedirect(reverse(networkIndex,args=(networkModel.pk,)))
+    return HttpResponseRedirect(reverse('pdep:network-index',args=(networkModel.pk,)))
 
 def networkDrawSVG(request, networkKey):
     """
@@ -258,7 +254,7 @@ def networkDrawSVG(request, networkKey):
     )
     
     # Go back to the network's main page
-    return HttpResponseRedirect(reverse(networkIndex,args=(networkModel.pk,)))
+    return HttpResponseRedirect(reverse('pdep:network-index',args=(networkModel.pk,)))
 
 def networkRun(request, networkKey):
     """
@@ -276,7 +272,7 @@ def networkRun(request, networkKey):
     )
     
     # Go back to the network's main page
-    return HttpResponseRedirect(reverse(networkIndex,args=(networkModel.pk,)))
+    return HttpResponseRedirect(reverse('pdep:network-index',args=(networkModel.pk,)))
 
 def networkSpecies(request, networkKey, species):
     """
@@ -302,19 +298,15 @@ def networkSpecies(request, networkKey, species):
         if conformer.E0:
             E0 = '{0:g}'.format(conformer.E0.value_si / 4184.)  # convert to kcal/mol
     
-    return render_to_response(
-        'networkSpecies.html', 
-        {
-            'network': networkModel, 
-            'networkKey': networkKey, 
-            'species': species, 
-            'label': label,
-            'structure': structure,
-            'E0': E0,
-            'hasTorsions': hasTorsions,
-        }, 
-        context_instance=RequestContext(request),
-    )
+    return render(request, 'networkSpecies.html',
+                  {'network': networkModel,
+                   'networkKey': networkKey,
+                   'species': species,
+                   'label': label,
+                   'structure': structure,
+                   'E0': E0,
+                   'hasTorsions': hasTorsions,
+                   })
 
 def computeMicrocanonicalRateCoefficients(network, T=1000):
     """
@@ -464,24 +456,20 @@ def networkPathReaction(request, networkKey, reaction):
     products_render = ' + '.join([getStructureMarkup(product) for product in reaction.products])
     arrow = '&hArr;' if reaction.reversible else '&rarr;'
     
-    return render_to_response(
-        'networkPathReaction.html', 
-        {
-            'network': networkModel, 
-            'networkKey': networkKey, 
-            'reaction': reaction, 
-            'index': index,
-            'reactants': reactants_render,
-            'products': products_render,
-            'arrow': arrow,
-            'E0': E0,
-            'conformer': conformer,
-            'hasTorsions': hasTorsions,
-            'kinetics': kinetics,
-            'microcanonicalRates': microcanonicalRates,
-        }, 
-        context_instance=RequestContext(request),
-    )
+    return render(request, 'networkPathReaction.html',
+                  {'network': networkModel,
+                   'networkKey': networkKey,
+                   'reaction': reaction,
+                   'index': index,
+                   'reactants': reactants_render,
+                   'products': products_render,
+                   'arrow': arrow,
+                   'E0': E0,
+                   'conformer': conformer,
+                   'hasTorsions': hasTorsions,
+                   'kinetics': kinetics,
+                   'microcanonicalRates': microcanonicalRates,
+                   })
 
 def networkNetReaction(request, networkKey, reaction):
     """
@@ -506,20 +494,16 @@ def networkNetReaction(request, networkKey, reaction):
     
     kinetics = reaction.kinetics
     
-    return render_to_response(
-        'networkNetReaction.html', 
-        {
-            'network': networkModel, 
-            'networkKey': networkKey, 
-            'reaction': reaction, 
-            'index': index,
-            'reactants': reactants,
-            'products': products,
-            'arrow': arrow,
-            'kinetics': kinetics,
-        }, 
-        context_instance=RequestContext(request),
-    )
+    return render(request, 'networkNetReaction.html',
+                  {'network': networkModel,
+                   'networkKey': networkKey,
+                   'reaction': reaction,
+                   'index': index,
+                   'reactants': reactants,
+                   'products': products,
+                   'arrow': arrow,
+                   'kinetics': kinetics,
+                   })
 
 def networkPlotKinetics(request, networkKey):
     """
@@ -559,20 +543,16 @@ def networkPlotKinetics(request, networkKey):
             products = u' + '.join([spec.label for spec in rxn.products])
             kineticsSet[products] = rxn.kinetics
     
-    return render_to_response(
-        'networkPlotKinetics.html', 
-        {
-            'form': form,
-            'network': networkModel, 
-            'networkKey': networkKey, 
-            'configurations': configurations, 
-            'source': source,
-            'kineticsSet': kineticsSet,
-            'T': T,
-            'P': P,
-        }, 
-        context_instance=RequestContext(request),
-    )
+    return render(request, 'networkPlotKinetics.html',
+                  {'form': form,
+                   'network': networkModel,
+                   'networkKey': networkKey,
+                   'configurations': configurations,
+                   'source': source,
+                   'kineticsSet': kineticsSet,
+                   'T': T,
+                   'P': P,
+                   })
 
 def networkPlotMicro(request, networkKey):
     """
@@ -663,13 +643,9 @@ def networkPlotMicro(request, networkKey):
                 'kdata': list(krlist),
             })
     
-    return render_to_response(
-        'networkPlotMicro.html', 
-        {
-            'network': networkModel, 
-            'networkKey': networkKey, 
-            'densityOfStatesData': densityOfStatesData,
-            'microKineticsData': microKineticsData,
-        }, 
-        context_instance=RequestContext(request),
-    )
+    return render(request, 'networkPlotMicro.html',
+                  {'network': networkModel,
+                   'networkKey': networkKey,
+                   'densityOfStatesData': densityOfStatesData,
+                   'microKineticsData': microKineticsData,
+                   })

--- a/rmgweb/rmg/templates/NASA.html
+++ b/rmgweb/rmg/templates/NASA.html
@@ -58,8 +58,8 @@ jQuery(document).ready(function() {
 {% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'rmg.views.index' %}">RMG Tools</a></li>
-<li><a href="{% url 'rmg.views.evaluateNASA' %}">Evaluate NASA Polynomial</a></li>
+<li><a href="{% url 'rmg:index' %}">RMG Tools</a></li>
+<li><a href="{% url 'rmg:evaluate-nasa' %}">Evaluate NASA Polynomial</a></li>
 {% endblock %}
 
 {% block page_title %}Evaluate NASA Polynomial{% endblock %}

--- a/rmgweb/rmg/templates/chemkinUpload.html
+++ b/rmgweb/rmg/templates/chemkinUpload.html
@@ -5,8 +5,8 @@
 {% block title %}Convert Chemkin File{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'rmg.views.index' %}">RMG Tools</a></li>
-<li><a href="{% url 'rmg.views.convertChemkin' %}">Convert Chemkin File</a></li>
+<li><a href="{% url 'rmg:index' %}">RMG Tools</a></li>
+<li><a href="{% url 'rmg:convert-chemkin' %}">Convert Chemkin File</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/rmg/templates/dictionaryUpload.html
+++ b/rmgweb/rmg/templates/dictionaryUpload.html
@@ -5,8 +5,8 @@
 {% block title %}Convert Adjacency Lists{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'rmg.views.index' %}">RMG Tools</a></li>
-<li><a href="{% url 'rmg.views.convertAdjlists' %}">Convert Adjacency Lists</a></li>
+<li><a href="{% url 'rmg:index' %}">RMG Tools</a></li>
+<li><a href="{% url 'rmg:convert-adjlists' %}">Convert Adjacency Lists</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/rmg/templates/fluxDiagram.html
+++ b/rmgweb/rmg/templates/fluxDiagram.html
@@ -20,8 +20,8 @@ $().ready(function() {
 {%endblock%}
 
 {% block navbar_items %}
-<li><a href="{% url 'rmg.views.index' %}">RMG Tools</a></li>
-<li><a href="{% url 'rmg.views.generateFlux' %}">Generate Flux Diagram</a></li>
+<li><a href="{% url 'rmg:index' %}">RMG Tools</a></li>
+<li><a href="{% url 'rmg:generate-flux' %}">Generate Flux Diagram</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/rmg/templates/input.html
+++ b/rmgweb/rmg/templates/input.html
@@ -33,7 +33,7 @@ function resolve(identifier_id){
 // convert an adjacency list into an image url
 function adjlist2img(s) {
    adjlist = encodeURI(s);
-   return "{% url 'main.views.drawMolecule' adjlist='ADJLIST' %}".replace('ADJLIST',adjlist);
+   return "{% url 'draw-molecule' adjlist='ADJLIST' %}".replace('ADJLIST',adjlist);
 }
 
 $(document).ready(function() {
@@ -229,7 +229,7 @@ blockquote {
 {% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'rmg.views.input' %}">Create Input File</a></li>
+<li><a href="{% url 'input' %}">Create Input File</a></li>
 {% endblock %}
 
 {% block page_title %}Create Input File{% endblock %}
@@ -273,7 +273,7 @@ If you already have a saved input.py file that you would like to modify, you can
     If no libraries are selected, RMG will estimate all species' thermochemistry through 
     Benson group additivity. We recommend using at least the 'primaryThermoLibrary'.
     
-    <P>You can browse the available libraries here: <a href="{% url 'database.views.thermo' section='libraries' %}" target="_blank">Thermodynamics Libraries</a>
+    <P>You can browse the available libraries here: <a href="{% url 'database:thermo' section='libraries' %}" target="_blank">Thermodynamics Libraries</a>
     <P>
     <table id="thermo_libraries">
         <thead><tr><th scope="col">Library</th></tr></thead>
@@ -303,7 +303,7 @@ If you already have a saved input.py file that you would like to modify, you can
     If you do not wish for these reactions to be automatically included in the core but do want to
     retain it in your mechanism, you may select the "Edge" option instead.
     <P>
-    You can browse the available libraries here: <a href="{% url 'database.views.kinetics' section='libraries' %}" target="_blank">Kinetics Libraries</a>
+    You can browse the available libraries here: <a href="{% url 'database:kinetics' section='libraries' %}" target="_blank">Kinetics Libraries</a>
     <P>
     <table id="reaction_libraries">
         <thead><tr><th scope="col">Library</th>

--- a/rmgweb/rmg/templates/inputResult.html
+++ b/rmgweb/rmg/templates/inputResult.html
@@ -5,7 +5,7 @@
 {% block title %}RMG: Input File Generated{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'rmg.views.input' %}">Create Input File</a></li>
+<li><a href="{% url 'input' %}">Create Input File</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/rmg/templates/javaKineticsLibrary.html
+++ b/rmgweb/rmg/templates/javaKineticsLibrary.html
@@ -5,8 +5,8 @@
 {% block title %}Convert Chemkin File{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'rmg.views.index' %}">RMG Tools</a></li>
-<li><a href="{% url 'rmg.views.javaKineticsLibrary' %}">Create RMG-Java Kinetics Library</a></li>
+<li><a href="{% url 'rmg:index' %}">RMG Tools</a></li>
+<li><a href="{% url 'rmg:java-kinetics-library' %}">Create RMG-Java Kinetics Library</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/rmg/templates/mergeModels.html
+++ b/rmgweb/rmg/templates/mergeModels.html
@@ -18,8 +18,8 @@ $().ready(function() {
 
 {%endblock%}
 {% block navbar_items %}
-<li><a href="{% url 'rmg.views.index' %}">RMG Tools</a></li>
-<li><a href="{% url 'rmg.views.mergeModels' %}">Merge Models</a></li>
+<li><a href="{% url 'rmg:index' %}">RMG Tools</a></li>
+<li><a href="{% url 'rmg:merge-models' %}">Merge Models</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/rmg/templates/modelCompare.html
+++ b/rmgweb/rmg/templates/modelCompare.html
@@ -18,8 +18,8 @@ $().ready(function() {
 
 {%endblock%}
 {% block navbar_items %}
-<li><a href="{% url 'rmg.views.index' %}">RMG Tools</a></li>
-<li><a href="{% url 'rmg.views.compareModels' %}">Model Comparison</a></li>
+<li><a href="{% url 'rmg:index' %}">RMG Tools</a></li>
+<li><a href="{% url 'rmg:compare-models' %}">Model Comparison</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/rmg/templates/plotKinetics.html
+++ b/rmgweb/rmg/templates/plotKinetics.html
@@ -17,16 +17,20 @@
 {% block page_body %}
 
 <p>
-Upload a chemkin file containing species thermodynamics and kinetics in order to plot both forward and reverse kinetics.
-You may upload an optional RMG Dictionary text file to draw the molecules
-and generate search links for individual reaction kinetics within the RMG database.  This dictionary file must
-include an adjacency list for all species in the chemkin file, including inerts and collider species.
+    Upload a chemkin file containing species thermodynamics and kinetics in order to plot both forward and reverse
+    kinetics. Species thermodynamics are required if you would like accurate reverse kinetics.
+</p>
+<p>
+    Uploading an RMG dictionary file will enable generation of species drawings and search links for the reactions
+    within RMG database. However, if the reactions to be plotted have pressure dependent kinetics with third-body
+    collider efficiencies, you MUST include a dictionary file including structures of all the colliders for proper
+    evaluation of the kinetics.
 </p>
 <hr/>
 
 <form enctype="multipart/form-data" action="" method="POST">{% csrf_token %}
 <P><b>Chemkin File:</b> {{form.ChemkinFile}}
-<P><b>Dictionary File (Optional):</b> {{form.DictionaryFile}}
+<P><b>Dictionary File:</b> {{form.DictionaryFile}}
 <P><b>Not an RMG-generated Chemkin file:</b> {{form.Foreign}}
 <p><input type="submit" value="Submit" id="submit"/></p>
 </form>

--- a/rmgweb/rmg/templates/plotKinetics.html
+++ b/rmgweb/rmg/templates/plotKinetics.html
@@ -5,8 +5,8 @@
 {% block title %}Plot Kinetics{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'rmg.views.index' %}">RMG Tools</a></li>
-<li><a href="{% url 'rmg.views.plotKinetics' %}">Plot Kinetics</a></li>
+<li><a href="{% url 'rmg:index' %}">RMG Tools</a></li>
+<li><a href="{% url 'rmg:plot-kinetics' %}">Plot Kinetics</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/rmg/templates/plotKineticsData.html
+++ b/rmgweb/rmg/templates/plotKineticsData.html
@@ -176,8 +176,8 @@ function showHide(elementid){
 {% endblock %}
 
 {% block navbar_items %}
-    <li><a href="{% url 'rmg.views.index' %}">RMG Tools</a></li>
-    <li><a href="{% url 'rmg.views.plotKinetics' %}">Plot Kinetics</a></li>
+    <li><a href="{% url 'rmg:index' %}">RMG Tools</a></li>
+    <li><a href="{% url 'rmg:plot-kinetics' %}">Plot Kinetics</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/rmg/templates/plotKineticsData.html
+++ b/rmgweb/rmg/templates/plotKineticsData.html
@@ -93,7 +93,7 @@ function calculateAverage() {
     count = 0;
     var highChartsSeriesIndex = 0
     refList = '';
-    {% for reactants, arrow, products, entry, kinetics, source, href, forward in kineticsDataList %}
+    {% for reactants, arrow, products, entry, kinetics, source, href, forward, chemkin, reversekinetics, chemkin_rev in kineticsDataList %}
     {% if kinetics %}
     if (visible[highChartsSeriesIndex]) {
         {{ kinetics|get_rate_coefficients:"A_n_Ea" }} {# returns A=, n=, Ea=, Aunits=, Eunits=, and Pnote= #}

--- a/rmgweb/rmg/templates/populateReactionsUpload.html
+++ b/rmgweb/rmg/templates/populateReactionsUpload.html
@@ -20,8 +20,8 @@ $().ready(function() {
 {%endblock%}
 
 {% block navbar_items %}
-<li><a href="{% url 'rmg.views.index' %}">RMG Tools</a></li>
-<li><a href="{% url 'rmg.views.runPopulateReactions' %}">Populate Reactions</a></li>
+<li><a href="{% url 'rmg:index' %}">RMG Tools</a></li>
+<li><a href="{% url 'rmg:run-populate-reactions' %}">Populate Reactions</a></li>
 {% endblock %}
 
 {% block sidebar_items %}

--- a/rmgweb/rmg/templates/rmg.html
+++ b/rmgweb/rmg/templates/rmg.html
@@ -7,7 +7,7 @@
 {% block extrahead %}{% endblock %}
 
 {% block navbar_items %}
-<li><a href="{% url 'rmg.views.index' %}">RMG Tools</a></li>
+<li><a href="{% url 'rmg:index' %}">RMG Tools</a></li>
 {% endblock %}
 
 {% block sidebar_items %}
@@ -19,21 +19,21 @@
 
 
     <ol>
-        <li><a href ="{% url 'rmg.views.convertChemkin' %}">Visualize Chemkin File</a>: visualize a model by supplying its chemkin file
+        <li><a href ="{% url 'rmg:convert-chemkin' %}">Visualize Chemkin File</a>: visualize a model by supplying its chemkin file
             and RMG-generated species dictionary.<P>
-        <li><a href ="{% url 'rmg.views.compareModels' %}">Model Comparison</a>: compare two RMG-generated models by supplying
+        <li><a href ="{% url 'rmg:compare-models' %}">Model Comparison</a>: compare two RMG-generated models by supplying
             their individual chemkin files and species dictionaries.<P>
-        <li><a href ="{% url 'rmg.views.convertAdjlists' %}">Convert Adjacency Lists</a>: convert adjacency lists in a text file to old-style adjacency lists
+        <li><a href ="{% url 'rmg:convert-adjlists' %}">Convert Adjacency Lists</a>: convert adjacency lists in a text file to old-style adjacency lists
         which are compatible with RMG-Java.<P>
-        <li><a href ="{% url 'rmg.views.mergeModels' %}">Merge Models</a>: merge two RMG-generated models by supplying
+        <li><a href ="{% url 'rmg:merge-models' %}">Merge Models</a>: merge two RMG-generated models by supplying
             their individual chemkin files and species dictionaries.<P>
-        <li><a href ="{% url 'rmg.views.generateFlux' %}">Generate Flux Diagram</a>: generate a flux diagram video by supplying a RMG input file and
+        <li><a href ="{% url 'rmg:generate-flux' %}">Generate Flux Diagram</a>: generate a flux diagram video by supplying a RMG input file and
             completed mechanism, or with a customized set of concentration profiles from a Chemkin job.<P>
-		<li><a href ="{% url 'rmg.views.runPopulateReactions' %}">PopulateReactions</a>: generate all possible reactions from a set of initial species.<P>
-		<li><a href="{% url 'rmg.views.plotKinetics' %}">Plot Kinetics</a>: plot forward and reverse kinetics by supplying a list of reactions in chemkin format along with a RMG dictionary.<P>
-		<li><a href="{% url 'rmg.views.javaKineticsLibrary' %}">Create RMG-Java Kinetics Library</a>: create an RMG-Java kinetics library for use as a seed-mechanism or reaction library by supplying a chemkin file along with a RMG dictionary.<P>
-		<li><a href="{% url 'rmg.views.evaluateNASA' %}">Evaluate NASA Polynomial</a>: View enthalpy, entropy, and heat capacity information in human readable format for a CHEMKIN format NASA polynomial.<P>
-		<li><a href="{% url 'database.views.groupDraw' %}">Draw Functional Group</a>: Draw an RMG group definition from its Adjacency List.<P>
+		<li><a href ="{% url 'rmg:run-populate-reactions' %}">PopulateReactions</a>: generate all possible reactions from a set of initial species.<P>
+		<li><a href="{% url 'rmg:plot-kinetics' %}">Plot Kinetics</a>: plot forward and reverse kinetics by supplying a list of reactions in chemkin format along with a RMG dictionary.<P>
+		<li><a href="{% url 'rmg:java-kinetics-library' %}">Create RMG-Java Kinetics Library</a>: create an RMG-Java kinetics library for use as a seed-mechanism or reaction library by supplying a chemkin file along with a RMG dictionary.<P>
+		<li><a href="{% url 'rmg:evaluate-nasa' %}">Evaluate NASA Polynomial</a>: View enthalpy, entropy, and heat capacity information in human readable format for a CHEMKIN format NASA polynomial.<P>
+		<li><a href="{% url 'rmg:group-draw' %}">Draw Functional Group</a>: Draw an RMG group definition from its Adjacency List.<P>
 					</ol>
 	
 {% endblock %}

--- a/rmgweb/rmg/urls.py
+++ b/rmgweb/rmg/urls.py
@@ -32,36 +32,38 @@ from django.conf.urls import url, include
 from rmgweb.rmg import views
 import rmgweb.database.views
 
+app_name='rmg'
+
 urlpatterns = [
     # RMG Simulation Homepage
-    url(r'^$', views.index),
+    url(r'^$', views.index, name='index'),
 
-    url(r'^group_draw', rmgweb.database.views.groupDraw),
+    url(r'^group_draw', rmgweb.database.views.groupDraw, name='group-draw'),
 
     # Convert Chemkin File to Output File
-    url(r'^chemkin', views.convertChemkin),
+    url(r'^chemkin', views.convertChemkin, name='convert-chemkin'),
 
     # Compare 2 RMG Models
-    url(r'^compare', views.compareModels),
+    url(r'^compare', views.compareModels, name='compare-models'),
     
     # Compare 2 RMG Models
-    url(r'^adjlist_conversion', views.convertAdjlists),
+    url(r'^adjlist_conversion', views.convertAdjlists, name='convert-adjlists'),
     
     # Merge 2 RMG Models
-    url(r'^merge_models', views.mergeModels),
+    url(r'^merge_models', views.mergeModels, name='merge-models'),
 
     # Generate Flux Diagram
-    url(r'^flux', views.generateFlux),
+    url(r'^flux', views.generateFlux, name='generate-flux'),
     
     # Populate Reactions with an Input File
-    url(r'^populate_reactions', views.runPopulateReactions),
+    url(r'^populate_reactions', views.runPopulateReactions, name='run-populate-reactions'),
     
     # Plot Kinetics
-    url(r'^plot_kinetics', views.plotKinetics),
+    url(r'^plot_kinetics', views.plotKinetics, name='plot-kinetics'),
     
     # Generate RMG-Java Kinetics Library
-    url(r'^java_kinetics_library', views.javaKineticsLibrary),
+    url(r'^java_kinetics_library', views.javaKineticsLibrary, name='java-kinetics-library'),
     
     # Evaluate NASA Polynomial
-    url(r'^evaluate_nasa', views.evaluateNASA),
+    url(r'^evaluate_nasa', views.evaluateNASA, name='evaluate-nasa'),
 ]

--- a/rmgweb/rmg/views.py
+++ b/rmgweb/rmg/views.py
@@ -31,7 +31,7 @@
 import os
 
 from django.forms.models import BaseInlineFormSet, inlineformset_factory
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import RequestContext
 
 from rmgweb.rmg.models import *
@@ -43,7 +43,7 @@ def index(request):
     """
     The RMG simulation homepage.
     """
-    return render_to_response('rmg.html', context_instance=RequestContext(request))
+    return render(request, 'rmg.html')
 
 def convertChemkin(request):
     """
@@ -62,14 +62,14 @@ def convertChemkin(request):
             # Generate the output HTML file
             chemkin.createOutput()
             # Go back to the network's main page
-            return render_to_response('chemkinUpload.html', {'form': form, 'path':path}, context_instance=RequestContext(request))
+            return render(request, 'chemkinUpload.html', {'form': form, 'path':path})
 
 
     # Otherwise create the form
     else:
         form = UploadChemkinForm(instance=chemkin)
         
-    return render_to_response('chemkinUpload.html', {'form': form,'path':path}, context_instance=RequestContext(request))
+    return render(request, 'chemkinUpload.html', {'form': form,'path':path})
 
 def convertAdjlists(request):
     """
@@ -88,13 +88,13 @@ def convertAdjlists(request):
             # Generate the output HTML file
             conversion.createOutput()
             # Go back to the network's main page
-            return render_to_response('dictionaryUpload.html', {'form': form, 'path':path}, context_instance=RequestContext(request))
+            return render(request, 'dictionaryUpload.html', {'form': form, 'path':path})
 
     # Otherwise create the form
     else:
         form = UploadDictionaryForm(instance=conversion)
         
-    return render_to_response('dictionaryUpload.html', {'form': form,'path':path}, context_instance=RequestContext(request))
+    return render(request, 'dictionaryUpload.html', {'form': form,'path':path})
 
 def compareModels(request):
     """
@@ -113,14 +113,14 @@ def compareModels(request):
             path = 'media/rmg/tools/compare/diff.html'
             # Generate the output HTML file
             diff.createOutput()
-            return render_to_response('modelCompare.html', {'form': form, 'path':path}, context_instance=RequestContext(request))
+            return render(request, 'modelCompare.html', {'form': form, 'path':path})
 
 
     # Otherwise create the form
     else:
         form = ModelCompareForm(instance=diff)
 
-    return render_to_response('modelCompare.html', {'form': form,'path':path}, context_instance=RequestContext(request))
+    return render(request, 'modelCompare.html', {'form': form,'path':path})
 
 
 def mergeModels(request):
@@ -140,11 +140,11 @@ def mergeModels(request):
             model.merge()
             path = 'media/rmg/tools/compare'
             #[os.path.join(model.path,'chem.inp'), os.path.join(model.path,'species_dictionary.txt'), os.path.join(model.path,'merging_log.txt')]
-            return render_to_response('mergeModels.html', {'form': form, 'path':path}, context_instance=RequestContext(request))
+            return render(request, 'mergeModels.html', {'form': form, 'path':path})
     else:
         form = ModelCompareForm(instance=model)
 
-    return render_to_response('mergeModels.html', {'form': form,'path':path}, context_instance=RequestContext(request))
+    return render(request, 'mergeModels.html', {'form': form,'path':path})
 
 
 
@@ -183,12 +183,12 @@ def generateFlux(request):
             # Look at number of subdirectories to determine where the flux diagram videos are
             subdirs = [name for name in os.listdir(flux.path) if os.path.isdir(os.path.join(flux.path, name))]
             subdirs.remove('species')
-            return render_to_response('fluxDiagram.html', {'form': form, 'path':subdirs}, context_instance=RequestContext(request))
+            return render(request, 'fluxDiagram.html', {'form': form, 'path':subdirs})
 
     else:
         form = FluxDiagramForm(instance=flux)
 
-    return render_to_response('fluxDiagram.html', {'form': form,'path':path}, context_instance=RequestContext(request))
+    return render(request, 'fluxDiagram.html', {'form': form,'path':path})
 
 
 def runPopulateReactions(request):
@@ -210,14 +210,14 @@ def runPopulateReactions(request):
             # Generate the output HTML file
             populateReactions.createOutput()
             # Go back to the network's main page
-            return render_to_response('populateReactionsUpload.html', {'form': form, 'output': outputPath, 'chemkin': chemkinPath}, context_instance=RequestContext(request))
+            return render(request, 'populateReactionsUpload.html', {'form': form, 'output': outputPath, 'chemkin': chemkinPath})
 
 
     # Otherwise create the form
     else:
         form = PopulateReactionsForm(instance=populateReactions)
         
-    return render_to_response('populateReactionsUpload.html', {'form': form, 'output': outputPath, 'chemkin': chemkinPath}, context_instance=RequestContext(request))
+    return render(request, 'populateReactionsUpload.html', {'form': form, 'output': outputPath, 'chemkin': chemkinPath})
 
 
 
@@ -302,16 +302,22 @@ def input(request):
                 posted = Input.objects.all()[0]
                 input.saveForm(posted, form)            
                 path = 'media/rmg/tools/input/input.py'            
-                return render_to_response('inputResult.html', {'path': path})
+                return render(request, 'inputResult.html', {'path': path})
             
             else:
                 # Will need more useful error messages later.
                 input_error = 'Your form was invalid.  Please edit the form and try again.'
        
-    return render_to_response('input.html', {'uploadform': uploadform, 'form': form, 'thermolibformset':thermolibformset,
-                                             'reactionlibformset':reactionlibformset, 'reactorspecformset':reactorspecformset,
-                                             'reactorformset':reactorformset, 'upload_error': upload_error, 
-                                             'input_error': input_error}, context_instance=RequestContext(request))
+    return render(request, 'input.html',
+                  {'uploadform': uploadform,
+                   'form': form,
+                   'thermolibformset':thermolibformset,
+                   'reactionlibformset': reactionlibformset,
+                   'reactorspecformset':reactorspecformset,
+                   'reactorformset': reactorformset,
+                   'upload_error': upload_error,
+                   'input_error': input_error,
+                   })
     
     
     
@@ -343,12 +349,13 @@ def plotKinetics(request):
         
                 
             
-        return render_to_response('plotKineticsData.html', {'kineticsDataList': kineticsDataList,
-                                                'plotWidth': 500,
-                                                'plotHeight': 400 + 15 * len(kineticsDataList),
-                                                'form': rateForm,
-                                                'eval':eval },
-                                         context_instance=RequestContext(request))
+        return render(request, 'plotKineticsData.html',
+                      {'kineticsDataList': kineticsDataList,
+                       'plotWidth': 500,
+                       'plotHeight': 400 + 15 * len(kineticsDataList),
+                       'form': rateForm,
+                       'eval': eval,
+                       })
 
     # Otherwise create the form
     else:
@@ -358,7 +365,7 @@ def plotKinetics(request):
         chemkin.deleteDir()
         form = UploadChemkinForm(instance=chemkin)
         
-    return render_to_response('plotKinetics.html', {'form': form}, context_instance=RequestContext(request))
+    return render(request, 'plotKinetics.html', {'form': form})
 
 
 def javaKineticsLibrary(request):
@@ -379,9 +386,8 @@ def javaKineticsLibrary(request):
         
                 
             
-        return render_to_response('javaKineticsLibrary.html', {'form': form,
-                                                'eval': eval },
-                                         context_instance=RequestContext(request))
+        return render(request, 'javaKineticsLibrary.html',
+                      {'form': form, 'eval': eval})
 
     # Otherwise create the form
     else:
@@ -391,7 +397,7 @@ def javaKineticsLibrary(request):
         chemkin.deleteDir()
         form = UploadChemkinForm(instance=chemkin)
         
-    return render_to_response('javaKineticsLibrary.html', {'form': form}, context_instance=RequestContext(request))
+    return render(request, 'javaKineticsLibrary.html', {'form': form})
 
 
 def evaluateNASA(request):
@@ -420,4 +426,4 @@ def evaluateNASA(request):
         
         form = NASAForm(initial, error_class=DivErrorList)
     
-    return render_to_response('NASA.html', {'form': form, 'thermo':thermo, 'thermoData':thermoData}, context_instance=RequestContext(request))
+    return render(request, 'NASA.html', {'form': form, 'thermo':thermo, 'thermoData':thermoData})

--- a/rmgweb/settings.py
+++ b/rmgweb/settings.py
@@ -116,7 +116,7 @@ TEMPLATES = [
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
                 # extra ones
-                "django.core.context_processors.request",  # adds 'request' to every view
+                "django.template.context_processors.request",  # adds 'request' to every view
                 # Custom context processors
                 'rmgweb.main.gitContext.getCommits', # gets git commit hashes
             ],

--- a/rmgweb/templates/base.html
+++ b/rmgweb/templates/base.html
@@ -62,7 +62,7 @@
     <div id="sidebar">
         <div id="logo">
             {% block sidebar_logo %}
-            <a href="{% url 'main.views.index' %}">
+            <a href="{% url 'index' %}">
                 <img src="{% static 'img/rmg-logo.png' %}" alt="RMG" height="100%"/>
             </a>
             {% endblock %}
@@ -77,7 +77,7 @@
             </div>
         </a>
 
-        <a href="{% url 'main.views.resources' %}">
+        <a href="{% url 'resources' %}">
             <div class="menuitem">
                 <img src="{% static 'img/resources-icon.png' %}" class="icon" width="100%"/>
                 <div class="menutext menutitle">Resources</div>
@@ -85,7 +85,7 @@
             </div>
         </a>
 
-        <a href="{% url 'database.views.index' %}">
+        <a href="{% url 'database:index' %}">
             <div class="menuitem">
                 <img src="{% static 'img/database-icon.png' %}" class="icon" width="100%"/>
                 <div class="menutext menutitle">Database</div>
@@ -93,7 +93,7 @@
             </div>
         </a>
 
-        <a href="{% url 'rmg.views.input' %}">
+        <a href="{% url 'input' %}">
             <div class="menuitem">
                 <img src="{% static 'img/input-icon.png' %}" class="icon" width="100%"/>
                 <div class="menutext menutitle">Create Input File</div>
@@ -101,7 +101,7 @@
             </div>
         </a>
 
-        <a href="{% url 'database.views.moleculeSearch' %}">
+        <a href="{% url 'molecule-search' %}">
             <div class="menuitem">
                 <img src="{% static 'img/molecule-icon.png' %}" class="icon" width="100%"/>
                 <div class="menutext menutitle">Molecule Search</div>
@@ -109,7 +109,7 @@
             </div>
         </a>
 
-        <a href="{% url 'database.views.kineticsSearch' %}">
+        <a href="{% url 'database:kinetics-search' %}">
             <div class="menuitem">
                 <img src="{% static 'img/kinetics-icon.png' %}" class="icon" width="100%"/>
                 <div class="menutext menutitle">Kinetics Search</div>
@@ -117,7 +117,7 @@
             </div>
         </a>
 
-        <a href="{% url 'database.views.solvationSearch' %}">
+        <a href="{% url 'database:solvation-search' %}">
             <div class="menuitem">
                 <img src="{% static 'img/solvation-icon.png' %}" class="icon" width="100%"/>
                 <div class="menutext menutitle">Solvation Search</div>
@@ -125,7 +125,7 @@
             </div>
         </a>
 
-        <a href="{% url 'pdep.views.index' %}">
+        <a href="{% url 'pdep:index' %}">
             <div class="menuitem">
                 <img src="{% static 'img/pdep-icon.png' %}" class="icon" width="100%"/>
                 <div class="menutext menutitle">Pressure Dependent Networks</div>
@@ -133,7 +133,7 @@
             </div>
         </a>
 
-        <a href="{% url 'rmg.views.index' %}">
+        <a href="{% url 'rmg:index' %}">
             <div class="menuitem">
                 <img src="{% static 'img/tools-icon.png' %}" class="icon" width="100%"/>
                 <div class="menutext menutitle">Other RMG Tools</div>
@@ -167,11 +167,11 @@
             <div class="user-toolbar">
                 <a class="user-button" onclick="toggleCSS()" href="#">Change Theme</a>
                 {% if user.is_authenticated %}
-                <a class="user-button" href="{% url 'main.views.viewProfile' user.username %}">{{ user.username }}</a>
-                <a class="user-button" href="{% url 'main.views.editProfile' %}">Edit Profile</a>
-                <a class="user-button" href="{% url 'main.views.logout' %}?next={{ request.path }}">Log Out</a>
+                <a class="user-button" href="{% url 'view-profile' user.username %}">{{ user.username }}</a>
+                <a class="user-button" href="{% url 'edit-profile' %}">Edit Profile</a>
+                <a class="user-button" href="{% url 'logout' %}?next={{ request.path }}">Log Out</a>
                 {% else %}
-                <a class="user-button" href="{% url 'main.views.login' %}?next={{ request.path }}">Log In</a>
+                <a class="user-button" href="{% url 'login' %}?next={{ request.path }}">Log In</a>
                 {% endif %}
             </div>
         </div>
@@ -179,7 +179,7 @@
         <div id="main">
             <div id="navbar">
                 <ul id="breadcrumb">
-                    <li><a href="{% url 'main.views.index' %}">Home</a></li>
+                    <li><a href="{% url 'index' %}">Home</a></li>
                     {% block navbar_items %}{% endblock %}
                 </ul>
             </div>
@@ -203,7 +203,7 @@
                 Read the <a href="/privacy">Privacy Policy</a>.
                 <br />
                 Last updated: {{ pds }} (RMG-Py), {{ dds }} (RMG-database), {{ wds }} (RMG-website).
-                See <a href="{% url 'main.views.version' %}">Backend Version</a> for details.
+                See <a href="{% url 'version' %}">Backend Version</a> for details.
                 {% endblock %}
             </div>
         </div>

--- a/rmgweb/templates/base.html
+++ b/rmgweb/templates/base.html
@@ -92,7 +92,7 @@
                 <div class="menutext menudesc">Browse the RMG database of chemical and kinetic parameters</div>
             </div>
         </a>
-
+{% comment %}
         <a href="{% url 'input' %}">
             <div class="menuitem">
                 <img src="{% static 'img/input-icon.png' %}" class="icon" width="100%"/>
@@ -100,6 +100,7 @@
                 <div class="menutext menudesc">Online form for making an RMG input file</div>
             </div>
         </a>
+{% endcomment %}
 
         <a href="{% url 'molecule-search' %}">
             <div class="menuitem">

--- a/rmgweb/tests/testURL.py
+++ b/rmgweb/tests/testURL.py
@@ -59,8 +59,8 @@ multiplicity 2
                                                                    'reactant2': reactant2,
                                                                    'resonance': False})
 
-        base_url = 'http://testserver/database/kinetics/results/reactant1={0}__reactant2={1}__res=False'
-        expected_url = iri_to_uri(base_url.format(reactant1, reactant2))
+        base_url = '/database/kinetics/results/reactant1={0}__reactant2={1}__res=False'
+        expected_url = iri_to_uri(base_url.format(reactant1.strip(), reactant2.strip()))
 
         self.assertRedirects(response, expected_url)
 

--- a/rmgweb/urls.py
+++ b/rmgweb/urls.py
@@ -55,29 +55,29 @@ urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     
     # Restart the django processes in the webserver
-    url(r'^restart$', rmgweb.main.views.restartWSGI),
+    url(r'^restart$', rmgweb.main.views.restartWSGI, name='restart-wsgi'),
     # Show debug info
-    url(r'^debug$', rmgweb.main.views.debug),
+    url(r'^debug$', rmgweb.main.views.debug, name='debug'),
     
     # The RMG website homepage
-    url(r'^$', rmgweb.main.views.index),
+    url(r'^$', rmgweb.main.views.index, name='index'),
     
     # The privacy policy
-    url(r'^privacy$', rmgweb.main.views.privacy),
+    url(r'^privacy$', rmgweb.main.views.privacy, name='privacy'),
     
     # Version information
-    url(r'^version$', rmgweb.main.views.version),
+    url(r'^version$', rmgweb.main.views.version, name='version'),
     
     # Additional resources page
-    url(r'^resources$', rmgweb.main.views.resources),
+    url(r'^resources$', rmgweb.main.views.resources, name='resources'),
 
     # User account management
-    url(r'^login$', rmgweb.main.views.login),
-    url(r'^logout$', rmgweb.main.views.logout),
-    url(r'^profile$', rmgweb.main.views.editProfile),
-    url(r'^signup', rmgweb.main.views.signup),
+    url(r'^login$', rmgweb.main.views.login, name='login'),
+    url(r'^logout$', rmgweb.main.views.logout, name='logout'),
+    url(r'^profile$', rmgweb.main.views.editProfile, name='edit-profile'),
+    url(r'^signup', rmgweb.main.views.signup, name='signup'),
     
-    url(r'^user/(?P<username>\w+)$', rmgweb.main.views.viewProfile),
+    url(r'^user/(?P<username>\w+)$', rmgweb.main.views.viewProfile, name='view-profile'),
 
     # Database
     url(r'^database/', include('rmgweb.database.urls')),
@@ -86,25 +86,25 @@ urlpatterns = [
     url(r'^pdep/', include('rmgweb.pdep.urls')),
 
     # Molecule drawing
-    url(r'^molecule/(?P<adjlist>[\S\s]+)$', rmgweb.main.views.drawMolecule),
-    url(r'^group/(?P<adjlist>[\S\s]+)$', rmgweb.main.views.drawGroup),
+    url(r'^molecule/(?P<adjlist>[\S\s]+)$', rmgweb.main.views.drawMolecule, name='draw-molecule'),
+    url(r'^group/(?P<adjlist>[\S\s]+)$', rmgweb.main.views.drawGroup, name='draw-group'),
     
-    url(r'^adjacencylist/(?P<identifier>.*)$', rmgweb.main.views.getAdjacencyList),
-    url(r'^cactus/(?P<query>.*)$', rmgweb.main.views.cactusResolver),
-    url(r'^nistcas/(?P<inchi>.*)$', rmgweb.main.views.getNISTcas),
+    url(r'^adjacencylist/(?P<identifier>.*)$', rmgweb.main.views.getAdjacencyList, name='get-adjacency-list'),
+    url(r'^cactus/(?P<query>.*)$', rmgweb.main.views.cactusResolver, name='cactus-resolver'),
+    url(r'^nistcas/(?P<inchi>.*)$', rmgweb.main.views.getNISTcas, name='get-nist-cas'),
 
     # Molecule and solvation search,  group drawing webpages
-    url(r'^molecule_search$', rmgweb.database.views.moleculeSearch),
-    url(r'^solvation_search', rmgweb.database.views.solvationSearch),
+    url(r'^molecule_search$', rmgweb.database.views.moleculeSearch, name='molecule-search'),
+    url(r'^solvation_search', rmgweb.database.views.solvationSearch, name='solvation-search'),
 
     # RMG-Py Stuff
     url(r'^tools/', include('rmgweb.rmg.urls')),
     
     # RMG Input Form
-    url(r'^input', rmgweb.rmg.views.input),
+    url(r'^input', rmgweb.rmg.views.input, name='input'),
     
     # Documentation auto-rebuild
-    url(r'^rebuild$', rmgweb.main.views.rebuild),
+    url(r'^rebuild$', rmgweb.main.views.rebuild, name='rebuild'),
 
     # Remember to update the /media/robots.txt file to keep web-crawlers out of pages you don't want indexed.
     

--- a/rmgweb/urls.py
+++ b/rmgweb/urls.py
@@ -86,9 +86,11 @@ urlpatterns = [
     url(r'^pdep/', include('rmgweb.pdep.urls')),
 
     # Molecule drawing
+    url(r'^molecule/(?P<adjlist>[\S\s]+)/(?P<format>\w+)$', rmgweb.main.views.drawMolecule, name='draw-molecule'),
     url(r'^molecule/(?P<adjlist>[\S\s]+)$', rmgweb.main.views.drawMolecule, name='draw-molecule'),
+    url(r'^group/(?P<adjlist>[\S\s]+)/(?P<format>\w+)$', rmgweb.main.views.drawGroup, name='draw-group'),
     url(r'^group/(?P<adjlist>[\S\s]+)$', rmgweb.main.views.drawGroup, name='draw-group'),
-    
+
     url(r'^adjacencylist/(?P<identifier>.*)$', rmgweb.main.views.getAdjacencyList, name='get-adjacency-list'),
     url(r'^cactus/(?P<query>.*)$', rmgweb.main.views.cactusResolver, name='cactus-resolver'),
     url(r'^nistcas/(?P<inchi>.*)$', rmgweb.main.views.getNISTcas, name='get-nist-cas'),

--- a/rmgweb/urls.py
+++ b/rmgweb/urls.py
@@ -101,7 +101,7 @@ urlpatterns = [
     url(r'^tools/', include('rmgweb.rmg.urls')),
     
     # RMG Input Form
-    url(r'^input', rmgweb.rmg.views.input, name='input'),
+    # url(r'^input', rmgweb.rmg.views.input, name='input'),
     
     # Documentation auto-rebuild
     url(r'^rebuild$', rmgweb.main.views.rebuild, name='rebuild'),


### PR DESCRIPTION
This PR includes changes necessary for updating to Django 1.11 LTS, which is the last version to support Python 2, removal of the input file generator, and other improvements and bug-fixes.

Changes for Django 1.11 compatibility:
- Replacement of `render_to_response` with `render`, which is now the recommended way to return HTTP responses
- Addition of URL names, which are now required for URL reversal
- Replacement of view targets with URL names in URL template tags
- Replacement of view targets with URL names in calls to `reverse`
- Fixed mismatches in number of variables used for tuple unpacking in for loops in templates

Input file generator:
- Access to page removed because the functionality was broken and also due to major security concerns

Improvements:
- InChI interpretation is now done by RMG (via RDKit/OpenBabel) instead of querying the NCI resolver
- Celsius option removed from rate evaluation form since RMG does not support it
- New message for when kinetics search does not return any results, so it's more clear that the request was properly processed
- Improved clarity of description/instructions for the plot kinetics tool
- Changed back to png images as the default for display on the website for better performance; however, there is now a link to download an SVG file for any molecule or group