### PR TITLE
Further improve error handling of adjacency list generation

### DIFF
--- a/rmgweb/main/views.py
+++ b/rmgweb/main/views.py
@@ -220,6 +220,8 @@ def getAdjacencyList(request, identifier):
         'oxygen': '[O][O]',
         'benzyl': '[CH2]c1ccccc1',
         'phenyl': '[c]1ccccc1',
+        'carbon monoxide': '[C-]#[O+]',
+        'co': '[C-]#[O+]',
     }
 
     # Ensure that input is a string


### PR DESCRIPTION
Since NCI resolver can return some weird structure. It is better to provide this information as well. NCI cannot parse carbon monoxide correctly, so we add it known_names.