### PR TITLE
Overwrite DEFAULT_FROM_EMAIL in the settings

### DIFF
--- a/rmgweb/secretsettings.py.example
+++ b/rmgweb/secretsettings.py.example
@@ -22,6 +22,8 @@ ADMINS = [
 EMAIL_HOST = 'outgoing.mit.edu'
 # Email address that outgoing error notifications are sent from
 SERVER_EMAIL = 'web@rmg.mit.edu'
+# Email address that password reset instructions are sent from
+DEFAULT_FROM_EMAIL = 'web@rmg.mit.edu'
 
 # The full path of the Django project (as determined from the location of this file)
 PROJECT_PATH = os.path.realpath(os.path.dirname(__file__))

--- a/rmgweb/settings.py
+++ b/rmgweb/settings.py
@@ -45,6 +45,7 @@ from rmgweb.secretsettings import (
     PROJECT_PATH,
     SECRET_KEY,
     SERVER_EMAIL,
+    DEFAULT_FROM_EMAIL,
 )
 
 # Local time zone for this installation. Choices can be found here:


### PR DESCRIPTION
This email address is used to sending emails from the website. It is relevant to password reset