### PR TITLE
BugFix: return the correct direction reaction when searching kinetics

### DIFF
--- a/rmgweb/database/views.py
+++ b/rmgweb/database/views.py
@@ -2176,10 +2176,7 @@ def kineticsResults(request, reactant1, reactant2='', reactant3='', product1='',
         arrow = '&hArr;' if reaction.reversible else '&rarr;'
         products = ' + '.join([getStructureInfo(product) for product in reaction.products])
         reaction_url = getReactionUrl(reaction, resonance=resonance)
-        if not forward:
-            reaction_data_list.append([reactants, arrow, products, count, reaction_url])
-        else:
-            reaction_data_list.append([products, arrow, reactants, count, reaction_url])
+        reaction_data_list.append([reactants, arrow, products, count, reaction_url])
 
     return render(request, 'kineticsResults.html', {'reactionDataList': reaction_data_list})
 


### PR DESCRIPTION
The previous BugFix b2fffe171e746afda8078830c3a5d9785347c8d2 returns the correct link, but makes the listing reaction in the wrong direction. This commit aims to fix this issue.