### PR TITLE
Add loading image and recommendations in kinetic search

### DIFF
--- a/rmgweb/database/templates/kineticsSearch.html
+++ b/rmgweb/database/templates/kineticsSearch.html
@@ -54,6 +54,13 @@ $(document).ready(function() {
       })
 // end of $(document).ready(function() {
 })
+// Show a loading animation when after hitting the submit button.
+$().ready(function(){
+   $('[name$=submit]').click(function() {
+      if ($('[name$=reactant1]').val()){
+         $('#searching').show(); }
+      });
+});
 </script>
 
 {% endblock %}
@@ -74,6 +81,15 @@ $(document).ready(function() {
 <p>You can search either by reactants only or by both reactants and products.</p>
 <p>Use the identifier fields to quickly fill the adjacency list boxes; they accept SMILES, InChI, species name
  <a href="http://cactus.nci.nih.gov/chemical/structure/documentation" title="Chemical identifier resolver documentation.">etc.</a></p>
+
+
+<div style="display:none" id="searching">
+<img src="{% static 'img/loading.gif' %}" alt="Loading..." id='loading_image'>
+   <p>Due to our server capacity,</p>
+   <p><strong>- Please wait patiently after submitting your search request. It may takes a few minutes.</strong></p>
+   <p><strong>- Please do not submit multiple kinetics searches simultaneously.</strong></p>
+   <p>If you keep receiving 'Gateway Timeout' error, it indicates your search takes longer time than the limit. Please contact <a href="mailto:rmg_dev@mit.edu">the RMG Development Team</a> for help.</p>
+</div>
 
 <form action="" method="POST">{% csrf_token %}
 <table>


### PR DESCRIPTION
RMG was done twice in the past two days. By looking at the access log and error log, it is clear that both events had the same cause:  A user requested a kinetic search of the molecule below (with generate_resonance=True).
![image](https://user-images.githubusercontent.com/35771233/100308467-775a8700-2f76-11eb-9f9a-890e2c8124c7.png)

This query takes very long (far exceeding our timeout limit). And what makes it worse, the user just impatiently relaunched the request multiple times in a very short period of time (within a few minutes). Then, all daemon processes were occupied, and all new requests were blocked.

In general, it is possible that some people will run into those time-consuming searches (or other functions). In that scenario, the connection between clients and the server will be terminated after some time, while the job on the server is still running, which blocks further requests. Ideally, we should have a script to kill them. However, according to my search, there isn’t much we can do with Django + Apache2 + mod_wsgi. Increasing the timeout doesn’t really solve the problem. The only way I found is running the potential time-consuming function in a separate process (with the multiprocessing module). However, when I tried this approach, it significantly increases the average searching time cost (sort of adding 10s process creating and communication cost for each search). Using `celery` may eventually solve this problem, but it involves a more significant refactoring.

Since the mentioned scenario is still rare now, it is okay to keep the efficiency with a little cost of stability. For now, I just modify the page and add some hints/recommendations as well as a loading image to let the user aware that the search is actually undergoing and multiple clicks are not recommended.