### PR TITLE
Load metal database

### DIFF
--- a/rmgweb/database/tools.py
+++ b/rmgweb/database/tools.py
@@ -198,6 +198,12 @@ class RMGWebDatabase(object):
                 if self.is_dir_modified(dirpath):
                     self.database.thermo.load_groups(dirpath)
                     self.reset_dir_timestamps(dirpath)
+            # Load metal database if necessary
+            if section in ['surface', '']:
+                dirpath = os.path.join(rmgweb.settings.DATABASE_PATH, 'surface')
+                if self.is_dir_modified(dirpath):
+                    self.database.thermo.load_surface()
+                    self.reset_dir_timestamps(dirpath)
 
         if component in ['transport', '']:
             if section in ['libraries', '']:


### PR DESCRIPTION
This is an update related to RMG-Py and RMG-database:
https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2025
https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2074
https://github.com/ReactionMechanismGenerator/RMG-database/pull/387

In the latest version RMG backend, a new RMG metal database was added to allow thermo estimations based on different metallic surfaces. In order to correctly load the metal database, the `load_surface()` function is called whenever reloading the RMG database (`load()`) / RMG thermo database (`load('thermo')`); `'surface'` is added as an optional section argument for `load` for potential future development. 