### PR TITLE
Add 2021 workshop to resources

### DIFF
--- a/rmgweb/main/templates/resources.html
+++ b/rmgweb/main/templates/resources.html
@@ -43,10 +43,17 @@
     </ol>
 
     <h2>RMG Workshop Recordings:</h2>
+
+    <p>
+    A series of talks given by RMG developers intended to teach users how to use RMG.
+    </p>
+
     <ol>
         <li><a href="https://tinyurl.com/RMG2019">2019 January</a></li>
+        <li><a href="https://www.youtube.com/playlist?list=PLZUqt5RldKbQWR1iJalegC-VjcxItpaXF">2021 January</a> and 
+            <a href="https://www.dropbox.com/sh/lwpqe65b2gq9d9p/AACe3vZlqjJKJOA4TDp07_6Sa?dl=0">relevant material</a></li>
     </ol>
-    
+
     {% if presentations %}
     <h2>RMG Study Group Presentations:</h2>
 


### PR DESCRIPTION
This update allows users to find the links to the 2021 workshop and relevant resources.