### PR TITLE
BugFix: handling unit of '1/XXX'

### DIFF
--- a/rmgweb/main/templatetags/render_kinetics.py
+++ b/rmgweb/main/templatetags/render_kinetics.py
@@ -120,7 +120,9 @@ def get_rate_unit_dimensionality(units):
         # Remove any parentheses and split by *
         parts = frac.replace('(', '').replace(')', '').split('*')
         for part in parts:
-            if '^' in part:
+            if '1' == part:
+                continue
+            elif '^' in part:
                 unit, power = part.split('^')
                 power = int(power)
             else:


### PR DESCRIPTION
Aims to solve #215.

In some cases,  a unit is written as 1/XXX (e.g., 1/s), which cannot be handled by the current RMG-website. This commit aims to solve that problem.