### PR TITLE
Compatibility with OpenBabel3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - mopac
   - nose
   - numpy >=1.10.0
-  - openbabel
+  - conda-forge::openbabel >= 3
   - psutil
   - pydas >=1.0.1
   - pydot

--- a/rmgweb/database/tools.py
+++ b/rmgweb/database/tools.py
@@ -38,7 +38,7 @@ import socket
 import sys
 
 import openbabel as ob
-import pybel
+from openbabel import pybel
 import xlrd
 from rmgpy.data.base import Entry
 from rmgpy.data.kinetics import KineticsDatabase, TemplateReaction


### PR DESCRIPTION
Updates RMG-website to accommodate recent upgrade to OpenBabel3. 

The [recent update to OpenBabel3 in RMG-Py](https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2088/files) changed the environment file; additionally there is an inconsistency with how `pybel` is imported between the two versions of OpenBabel. This PR seeks to address those inconsistencies.