### PR TITLE
Add hyperlinks to group additivity thermo estimates

### DIFF
--- a/rmgweb/database/templates/thermoData.html
+++ b/rmgweb/database/templates/thermoData.html
@@ -75,7 +75,15 @@ You must <a href="{% url 'login' %}?next={{ request.path }}">log in first.</a>
 <p>Species label: {{ entry.label }}</p>
 {% endif %}
 {% if source == 'Group additivity' %}
-Comments: {{ thermo.comment }} 
+<p>
+Comments: 
+{% for word in word_list %}
+{% if word in ref_dict %}
+<a href="{{ref_dict|get_items:word}}"> {{word}} </a>
+{% else %}
+{{word}}
+{% endif %}
+{% endfor %}
 <P>
 Symmetry number: {{ symmetry_number }}
 <p>

--- a/rmgweb/main/templatetags/render_thermo.py
+++ b/rmgweb/main/templatetags/render_thermo.py
@@ -339,3 +339,15 @@ def get_thermo_data(thermo, user=None):
     except:
         # don't fail completely if thermo data is incomplete
         return ''
+
+################################################################################
+
+
+@register.filter
+def get_items(dictionary, key):
+    '''
+    By default, Django does not let the user lookup a dictionary value if the key is the loop variable.
+    This filter is a workaround to enable using loop variable as a key in a view.
+    '''
+    return dictionary.get(key)
+    


### PR DESCRIPTION
Implements feature suggested in #214.

When group additivity thermo estimations are generated, typically a `comment` is added that informs what library and/or groups were used to generate that estimate. This comment is then displayed by the website. This implementation implements a new feature that automatically links to the relevant library or groups in the reported thermo comment whenever they are detected.

Sample implementation:
[(1) Species in original feature request](https://rmg.mit.edu:888/database/thermo/molecule/1%20O%20u0%20p2%20c0%20%7B3,S%7D%20%7B5,S%7D%0A2%20O%20u0%20p2%20c0%20%7B3,D%7D%0A3%20C%20u0%20p0%20c0%20%7B1,S%7D%20%7B2,D%7D%20%7B4,S%7D%0A4%20X%20u0%20p0%20c0%20%7B3,S%7D%0A5%20X%20u0%20p0%20c0%20%7B1,S%7D%0A)
[(2) Example of handling missing groups](https://rmg.mit.edu:888/database/thermo/molecule/1%20C%20u0%20p0%20c0%20%7B2,D%7D%20%7B4,S%7D%20%7B5,S%7D%0A2%20C%20u0%20p0%20c0%20%7B1,D%7D%20%7B3,D%7D%0A3%20O%20u0%20p2%20c0%20%7B2,D%7D%0A4%20H%20u0%20p0%20c0%20%7B1,S%7D%0A5%20H%20u0%20p0%20c0%20%7B1,S%7D%0A)
[(3) Unusual/many groups ](https://rmg.mit.edu:888/database/thermo/molecule/1%20%20C%20u0%20p0%20c0%20%7B2,S%7D%20%7B7,S%7D%20%7B19,S%7D%20%7B20,S%7D%0A2%20%20C%20u0%20p0%20c0%20%7B1,S%7D%20%7B3,S%7D%20%7B21,S%7D%20%7B22,S%7D%0A3%20%20C%20u0%20p0%20c0%20%7B2,S%7D%20%7B4,S%7D%20%7B5,S%7D%20%7B23,S%7D%0A4%20%20C%20u0%20p0%20c0%20%7B3,S%7D%20%7B5,S%7D%20%7B6,S%7D%20%7B24,S%7D%0A5%20%20O%20u0%20p2%20c0%20%7B3,S%7D%20%7B4,S%7D%0A6%20%20C%20u0%20p0%20c0%20%7B4,S%7D%20%7B7,S%7D%20%7B25,S%7D%20%7B26,S%7D%0A7%20%20C%20u0%20p0%20c0%20%7B1,S%7D%20%7B6,S%7D%20%7B8,S%7D%20%7B27,S%7D%0A8%20%20C%20u0%20p0%20c0%20%7B7,S%7D%20%7B9,S%7D%20%7B28,S%7D%20%7B29,S%7D%0A9%20%20O%20u0%20p2%20c0%20%7B8,S%7D%20%7B10,S%7D%0A10%20C%20u0%20p0%20c0%20%7B9,S%7D%20%7B11,D%7D%20%7B12,S%7D%0A11%20O%20u0%20p2%20c0%20%7B10,D%7D%0A12%20C%20u0%20p0%20c0%20%7B10,S%7D%20%7B13,S%7D%20%7B17,S%7D%20%7B30,S%7D%0A13%20C%20u0%20p0%20c0%20%7B12,S%7D%20%7B14,S%7D%20%7B31,S%7D%20%7B32,S%7D%0A14%20C%20u0%20p0%20c0%20%7B13,S%7D%20%7B15,S%7D%20%7B33,S%7D%20%7B34,S%7D%0A15%20C%20u0%20p0%20c0%20%7B14,S%7D%20%7B16,S%7D%20%7B18,S%7D%20%7B35,S%7D%0A16%20C%20u0%20p0%20c0%20%7B15,S%7D%20%7B17,S%7D%20%7B18,S%7D%20%7B36,S%7D%0A17%20C%20u0%20p0%20c0%20%7B12,S%7D%20%7B16,S%7D%20%7B37,S%7D%20%7B38,S%7D%0A18%20O%20u0%20p2%20c0%20%7B15,S%7D%20%7B16,S%7D%0A19%20H%20u0%20p0%20c0%20%7B1,S%7D%0A20%20H%20u0%20p0%20c0%20%7B1,S%7D%0A21%20H%20u0%20p0%20c0%20%7B2,S%7D%0A22%20H%20u0%20p0%20c0%20%7B2,S%7D%0A23%20H%20u0%20p0%20c0%20%7B3,S%7D%0A24%20H%20u0%20p0%20c0%20%7B4,S%7D%0A25%20H%20u0%20p0%20c0%20%7B6,S%7D%0A26%20H%20u0%20p0%20c0%20%7B6,S%7D%0A27%20H%20u0%20p0%20c0%20%7B7,S%7D%0A28%20H%20u0%20p0%20c0%20%7B8,S%7D%0A29%20H%20u0%20p0%20c0%20%7B8,S%7D%0A30%20H%20u0%20p0%20c0%20%7B12,S%7D%0A31%20H%20u0%20p0%20c0%20%7B13,S%7D%0A32%20H%20u0%20p0%20c0%20%7B13,S%7D%0A33%20H%20u0%20p0%20c0%20%7B14,S%7D%0A34%20H%20u0%20p0%20c0%20%7B14,S%7D%0A35%20H%20u0%20p0%20c0%20%7B15,S%7D%0A36%20H%20u0%20p0%20c0%20%7B16,S%7D%0A37%20H%20u0%20p0%20c0%20%7B17,S%7D%0A38%20H%20u0%20p0%20c0%20%7B17,S%7D%0A)
[(4) Simple surface example](https://rmg.mit.edu:888/database/thermo/molecule/1%20O%20u0%20p2%20c0%20%7B2,D%7D%0A2%20X%20u0%20p0%20c0%20%7B1,D%7D%0A)
[(5) Edge case: No group additivity comment](https://rmg.mit.edu:888/database/thermo/molecule/1%20X%20u0%20p2%20c0)
[(6) Both library + group used to estimate gas phase thermo](https://rmg.mit.edu:888/database/thermo/molecule/1%20O%20u0%20p2%20c0%20%7B2,D%7D%0A2%20C%20u0%20p0%20c0%20%7B1,D%7D%20%7B3,D%7D%0A3%20X%20u0%20p0%20c0%20%7B2,D%7D%0A) 
  
This string depends on thermo comments being formatted partially in a specific way. It is somewhat flexible with detecting groups, but very structure-dependent for detecting libraries. Some other potential ways to implement this:
- Generate group & library information in `thermo` when GAV are generated, pass them up to the website, and link them. (That is, generate fields specifically for GAV info - not just tucked away in the comment). But this would require changes in `RMG-Py`. 
- Parse every word in the comment and lookup whether each word is a `label` for a library or a group. But this seems inefficient.
- Make sure comments are structured very specifically. This is already the case because only a few functions currently generate comment fields, so they are easy to make consistent. Labeling groups like `group(Cs-HHHH)` are both consistent and helpful (for the user and devs!) but is least flexible in case a new feature builds on the current comment implementation.