### PR TITLE
Fix to slow individual kinetics family entry pages

### DIFF
--- a/rmgweb/database/views.py
+++ b/rmgweb/database/views.py
@@ -1399,7 +1399,15 @@ def kinetics(request, section='', subsection=''):
         # database components
         kinetics_libraries = [(label, library) for label, library in database.kinetics.libraries.items() if subsection in label]
         kinetics_libraries.sort()
-        for family in database.kinetics.families.values():
+        
+        # If this is a subsection, but not the main kinetics page,
+        # we don't need to iterate through the entire database, as this takes a long time to load.
+        try:
+            families_to_process = [database.kinetics.families[subsection]]
+        except KeyError: # if main kinetics page, or some other error
+            families_to_process = database.kinetics.families.values()
+
+        for family in families_to_process:
             for i in range(0, len(family.depositories)):
                 if 'untrained' in family.depositories[i].name:
                     family.depositories.pop(i)


### PR DESCRIPTION
This PR seeks to fix a bug that causes individual family kinetics pages to load extremely slowly.

Requests to all kinetics sites are handled in the `kinetics` function. The code attempts to generate a KineticsDatabase object depending on the subsection of kinetics (e.g. `groups`, `training`, `rules`, if present) and family name (if present).
If no valid KineticsDatabase object is found (such as when the subsection is not able to be parsed `get_kinetics_database` e.g. does not fall under `groups` or `training`, etc) then the website attempts to render the "list view" [See https://rmg.mit.edu/database/kinetics/families/ for the "list view" of all families]. It is possible to specify the _family name_ as the subsection, which results in loading the list view only for that family.
 
In the current implementation of loading the "list view", the entire database is loaded and processed regardless of whether you are listing all families or 1 family. Processing families is expensive because the function `getUntrainedReactions` scales with depository size & number. 
The proposed change seeks to fix this by only processing the family being queried when "list view" is called.

**Examples:** 
Small family -  [Current site (slow)](https://rmg.mit.edu/database/kinetics/families/Korcek_step1_cat/) vs. [fixed site (fast) ](https://rmg.mit.edu:888/database/kinetics/families/Korcek_step1_cat/)
Big family - [Current site (slow)](https://rmg.mit.edu/database/kinetics/families/R_Addition_MultipleBond/) vs. [fixed site (fast)](https://rmg.mit.edu:888/database/kinetics/families/R_Addition_MultipleBond/)