### PR TITLE
Fix typo in processing Wilhoit thermo that leads to AttributeError

### DIFF
--- a/rmgweb/main/templatetags/render_thermo.py
+++ b/rmgweb/main/templatetags/render_thermo.py
@@ -117,12 +117,12 @@ def render_thermo_math(thermo, user=None):
         result += '<tr>'
         result += r'    <td class="key"><script type="math/tex">C_\mathrm{p}(0)</script></td>'
         result += r'    <td class="equals">=</td>'
-        result += r'    <td class="value"><script type="math/tex">{0:.2f} \ \mathrm{{ {1!s}  }}</script></td>'.format(thermo.cp0.value_si * Cpfactor, Cpunits)
+        result += r'    <td class="value"><script type="math/tex">{0:.2f} \ \mathrm{{ {1!s}  }}</script></td>'.format(thermo.Cp0.value_si * Cpfactor, Cpunits)
         result += '</tr>\n'
         result += '<tr>'
         result += r'    <td class="key"><script type="math/tex">C_\mathrm{p}(\infty)</script></td>'
         result += r'    <td class="equals">=</td>'
-        result += r'    <td class="value"><script type="math/tex">{0:.2f} \ \mathrm{{ {1!s} }}</script></td>'.format(thermo.cpInf.value_si * Cpfactor, Cpunits)
+        result += r'    <td class="value"><script type="math/tex">{0:.2f} \ \mathrm{{ {1!s} }}</script></td>'.format(thermo.CpInf.value_si * Cpfactor, Cpunits)
         result += '</tr>\n'
         result += '<tr>'
         result += r'    <td class="key"><script type="math/tex">a_0</script></td>'


### PR DESCRIPTION
### Issue
When searching for species involving Wilhoit thermo, the website will crash upon rendering the thermo view, citing an `AttributeError`.

### Recreate issue
Search "CCC" in the Molecule Search --> Search Thermochemistry leads to the `AttributeError`. [Example here](https://rmg.mit.edu/database/thermo/molecule/multiplicity%202%0A1%20%20C%20%20u0%20p0%20c0%20%7B2,S%7D%20%7B5,S%7D%20%7B6,S%7D%20%7B7,S%7D%0A2%20%20C%20%20u1%20p0%20c0%20%7B1,S%7D%20%7B3,S%7D%20%7B4,S%7D%0A3%20%20Cl%20u0%20p3%20c0%20%7B2,S%7D%0A4%20%20C%20%20u0%20p0%20c0%20%7B2,S%7D%20%7B8,S%7D%20%7B9,S%7D%20%7B10,S%7D%0A5%20%20H%20%20u0%20p0%20c0%20%7B1,S%7D%0A6%20%20H%20%20u0%20p0%20c0%20%7B1,S%7D%0A7%20%20H%20%20u0%20p0%20c0%20%7B1,S%7D%0A8%20%20H%20%20u0%20p0%20c0%20%7B4,S%7D%0A9%20%20H%20%20u0%20p0%20c0%20%7B4,S%7D%0A10%20H%20%20u0%20p0%20c0%20%7B4,S%7D%0A) 
This affects ~20 species, generally those with thermo from the Chlorination library.

## Fix
The issue is caused by a minor typo in `render_thermo.py`. The attribute heat capacity is capitalized, not lowercase. 
I have verified on a local instance of the website that this fixes the error.