### PR TITLE
Update `chemprop_solvation` with a newer version >=0.0.3 to fix a bug with SoluteML

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - beautifulsoup4
   - cairo
   - cairocffi
-  - chemprop_solvation
+  - chemprop_solvation >=0.0.3
   - coverage
   - cython >=0.25.2
   - docutils

--- a/rmgweb/database/views.py
+++ b/rmgweb/database/views.py
@@ -1007,7 +1007,8 @@ def get_solute_data_from_SoluteML(smiles, solute_spc, error_msg):
             raise ImportError(f'Please install "descriptastorus" to use the SoluteML model.\n'
                               f'Run the following line to install "descriptastorus":\n'
                               f'\tpip install git+https://github.com/bp-kelley/descriptastorus\n'
-                              'If "descriptastorus" is already installed, please update "chemprop_solvation".')
+                              'If "descriptastorus" is already installed, please update "chemprop_solvation" with'
+                              'version 0.0.3 or higher.')
         else:
             error_msg = update_error_msg(error_msg, 'Unable to parse the SMILES', overwrite=True)
     # get V value using RMG


### PR DESCRIPTION
One of the packages (chemprop_solvation) has a bug and needs to be updated in order for the SoluteML solvation tool to work properly on RMG-website. This PR will fix it.

Please run:
`conda env update -f environment.yml`
`pip install git+https://github.com/bp-kelley/descriptastorus`

Then the Solute parameter search tool on https://rmg.mit.edu/database/solvation/soluteSearch/ with `Machine Learning Prediction (SoluteML)` as an estimation method will work.
Test this by entering the following input:
`[H][H] C(CBr)O c1ccccc1 C(C)(=O)O C1=CC=CC2=CC=CC=C12 lllllll Mg`
Choose `Machine Learning Prediction (SoluteML)` as an estimation method and `water` as a solvent.
You should get a table showing results below:

![image](https://user-images.githubusercontent.com/17207530/131865464-bd9cf1d0-e58d-46f0-a0b1-d4828380531b.png)
![image](https://user-images.githubusercontent.com/17207530/131865042-ea0b80be-0536-41ab-997d-677e495afba7.png)

