### PR TITLE
Fix to conda environment incompatibility error by adding pytorch dependency for chemprop_solvation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
   - rmg
   - rdkit
   - conda-forge
+  - pytorch
   - fhvermei
 dependencies:
   - beautifulsoup4
@@ -31,9 +32,12 @@ dependencies:
   - pydqed >=1.0.0
   - pyparsing
   - python >=3.7
+  - pytorch
   - quantities
   - scipy
   - symmetry
+  - torchvision
+  - torchaudio
   - rdkit >=2018
   - xlrd
   - xlsxwriter


### PR DESCRIPTION
### Short description
Adds missing dependencies that previously caused the conda environment to fail to properly build due to recent `chemprop_solvation` install.
[more info on the incompatibility can be found in this thread.](https://github.com/pytorch/pytorch/issues/59222#issuecomment-863390401)

### Long description
Previously, @xiaoruiDong and I observed a strange glitch related to building the RMG website.  While updating the main RMG website, we observed that creating the `rmg_env` specified by `RMG-Py` and `RMG-website` (I will call this the "canonical" environment) led to a package compatibility error. Our short-term solution was to clone the dev environment to the main environment. However, this solution cannot be extended indefinitely because it does not solve the core issue (being unable to update environments). It was also confusing to us why we experienced a package compatibility error if the websites were working perfectly fine.

To troubleshoot, here are the steps I took:

1. Roll back `RMG-website` to earliest commit with a working `environment.yml` (if this didn't work, we would have also tried rolling back `RMG-Py`
2. Noting that the recent commit involving adding  `chemprop_solvation` to the environment led to the inconsistencies, my first thought was that the package might be conflicting with the `chemprop` installed in `RMG-Py`. I tried redoing the installation process by removing `chemprop` from the RMG-Py environment before installing RMG-website but still ran into the same error. This indicated that the error was instead with another package!
3. The next logical step is that there is possibly a dependency in `chemprop_solvation` that conflicts with the other packages.  I checked using `conda search chemprop_solvation -c fhvermei --info` and compared to the canonical environment minus `chemprop_solvation`. I observed that the canonical environment included all of `chemprop_solvation`'s dependencies _except_ for `pytorch`.
4. Simultaneously, I compared the "working" website environment with `chemprop_solvation` to the canonical environment minus `chemprop_solvation`. I observed that there were several package differences, but most importantly, the working website had `pytorch` in the environment.
5. To confirm `pytorch` was the source of the error, I tried installing `pytorch` using the default conda channels in the canonical environment minus `chemprop_solvation` and ran into... the package incompatibility error.  Finally, properly installing `pytorch` fixed the issue, so I tried a fresh install by modifying `environment.yml` and the error was fixed!