### PR TITLE
Update resources with link for RMG v3.0 publication.

### DIFF
--- a/rmgweb/main/templates/resources.html
+++ b/rmgweb/main/templates/resources.html
@@ -26,6 +26,10 @@
 
     <ol>
         <li>
+            Liu, M.; Dana, A. G.; Johnson, M. S.; Goldman, M. J.; Jocher, A.; Payne, A. M.; Grambow, C. A.; Han, K.; Yee, N. W.; Mazeau, E. J.; Blondal, K.; West, R. H.; Goldsmith,  C. F.; Green, W. H. Reaction Mechanism Generator v3.0: Advances in Automatic Mechanism Generation. J. Chem. Inf. Model. 2021, 61, 2686-2696.
+            <a href="https://pubs.acs.org/doi/abs/10.1021/acs.jcim.0c01480">Link</a>
+        </li>
+        <li>
             Gao, C. W.; Allen, J. W.; Green, W. H.; West, R. H. Reaction Mechanism Generator: Automatic Construction of
             Chemical Kinetic Mechanisms. Comput. Phys. Commun. 2016, 203, 212–225.
             <a href="http://www.sciencedirect.com/science/article/pii/S0010465516300285">Link</a>


### PR DESCRIPTION
**Old:**
[Old resources](https://rmg.mit.edu/resources)

**New:**
[New resources](https://rmg.mit.edu:888/resources)