### PR TITLE
Add hyperlink link to the groups for the solvation group contribution method

### DIFF
--- a/rmgweb/database/templates/solvationSoluteSearch.html
+++ b/rmgweb/database/templates/solvationSoluteSearch.html
@@ -36,7 +36,9 @@ Use this form to find the Abraham solute parameters (E, S, A, B, L, V). Currentl
    <li><b>RMG-database</b>: get the experimental values from the RMG-database
       <a href="{% url 'database:solvation' section='libraries' subsection='solute' %}" target="_blank">solute library</a>
       if they exist.</li>
-   <li><b>SoluteGC</b>: get the prediction using the group contribution (a.k.a. group additivity) method.</li>
+   <li><b>SoluteGC</b>: get the prediction using the group contribution (a.k.a. group additivity) method.
+   A list of all solvation groups is found
+      <a href="{% url 'database:solvation' section='groups' %}">here</a>.</li>
    <li><b>SoluteML</b>: get the prediction using the machine learning model. This is usually
       more accurate than the SoluteGC method.</li>
 </ul>


### PR DESCRIPTION
**Motivation**

Currently, the [Solute and Solvation LSER Search](https://rmg.mit.edu/database/solvation/soluteSearch/) using the group contribution method only displays the name of the groups found for the input molecules as shown below.

![current_soluteGc](https://user-images.githubusercontent.com/17207530/142040074-e81f259b-43bb-4bd7-af1b-8b2361fd41ca.png)

This is inconvenient since the user has to search for each group if they want to know the group value.

**Changes Made**

This commit now adds the hyperlink to each group found for the group contribution method as shown below. Clicking each group will direct the user to the page containing the detailed information of the group.

![SoluteGC](https://user-images.githubusercontent.com/17207530/142040250-519a511f-7db7-4d71-84e7-2b838dd0f1aa.png)

Similar changes have been made for the solute parameter search using the RMG-database. Clicking the comment will direct the user to the page containing the matched library entry.

![solute_library](https://user-images.githubusercontent.com/17207530/142040345-31afe1df-41a9-48fd-a3da-5397d0702433.png)

