### PR TITLE
Downgrade solprop from >=1.2 to =1.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
   - pytorch
   - quantities
   - scipy
-  - solprop_ml >=1.1
+  - solprop_ml=1.1
   - symmetry
   - torchvision
   - torchaudio


### PR DESCRIPTION
The version 1.2 of the solprop package version is currently broken out-of-the-box. This commit just changes the version number in the `environment.yml` file to 1.1 (which is known to be stable) as a fix is prepared.