### PR TITLE
Added 2022 RMG database paper to resources tab

### DIFF
--- a/rmgweb/main/templates/resources.html
+++ b/rmgweb/main/templates/resources.html
@@ -26,6 +26,10 @@
 
     <ol>
         <li>
+            Johnson, M. S.; Dong, X.; Dana, A. G.; Chung, Y.; Farina, D., Jr.; Gillis, R. J.; Liu, M.; Yee, N. W.; Blondal, K.; Mazeau, E. J.; Grambow, C. A.; Payne, A. M.; Spiekermann, K. A.; Pang, H. W.; Goldsmith, C. F.; West, R. H.; Green, W. H. RMG Database for Chemical Property Prediction. J. Chem. Inf. Model. 2022, 62, 4906-4915.
+            <a href="https://pubs.acs.org/doi/10.1021/acs.jcim.2c00965">Link</a>
+        </li>
+        <li>
             Liu, M.; Dana, A. G.; Johnson, M. S.; Goldman, M. J.; Jocher, A.; Payne, A. M.; Grambow, C. A.; Han, K.; Yee, N. W.; Mazeau, E. J.; Blondal, K.; West, R. H.; Goldsmith,  C. F.; Green, W. H. Reaction Mechanism Generator v3.0: Advances in Automatic Mechanism Generation. J. Chem. Inf. Model. 2021, 61, 2686-2696.
             <a href="https://pubs.acs.org/doi/abs/10.1021/acs.jcim.0c01480">Link</a>
         </li>


### PR DESCRIPTION
Adds a link to the 2022 RMG database paper, [RMG Database for Chemical Property Prediction](https://pubs.acs.org/doi/10.1021/acs.jcim.2c00965) to the Resources tab on the website.