### PR TITLE
Update environment.yml to latest version of solprop

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
   - pytorch
   - quantities
   - scipy
-  - solprop_ml=1.1
+  - solprop_ml >=1.2
   - symmetry
   - torchvision
   - torchaudio


### PR DESCRIPTION
Previously, solprop version 1.2 had a critical error so a previous PR (#242) was introduced to downgrade it. This PR undoes the downgrade as the latest version of solprop is now stable.