### PR TITLE
Update tracker from Google UA to GA4

### DIFF
--- a/rmgweb/templates/base.html
+++ b/rmgweb/templates/base.html
@@ -14,17 +14,14 @@
     <link href="{% static 'css/default.css' %}?v=2.0" rel="stylesheet" type="text/css"/>
     <link id="css-theme" href="{% static 'css/light-theme.css' %}" rel="stylesheet" type="text/css"/>
 
-    <!-- Google Analytics Tracker -->
-    <script type="text/javascript">
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', 'UA-24556433-1']);
-      _gaq.push(['_setDomainName', 'rmg.mit.edu']);
-      _gaq.push(['_trackPageview']);
-      (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
+    <!-- Google Analytics Tracker tag -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-KELSC0QZQS"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+
+        gtag('config', 'G-KELSC0QZQS');
     </script>
 
     <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>


### PR DESCRIPTION
The RMG website used Google Universal Analytics to track and understand user behavior. The universal analytics stopped working on 2023/07/01. I just tried to migrate services to Google Analytics 4. This PR adds the necessary tag to enable GA4.

@jonwzheng I suggest we test this on the dev first, and then eventually merge it onto the website.