### PR TITLE
Fix kinetic search due to removal of group additivity methods for rates from RMG-Py

### DIFF
--- a/rmgweb/database/tools.py
+++ b/rmgweb/database/tools.py
@@ -420,9 +420,10 @@ def generateReactions(database, reactants, products=None, only_families=None, re
 
             # Get all of the kinetics for the reaction
             family = get_family_library_object(reaction.family)
-            kinetics_list = family.get_kinetics(reaction, template_labels=reaction.template, degeneracy=reaction.degeneracy, return_all_kinetics=True)
+            kinetics_list = family.get_kinetics(reaction, template_labels=reaction.template, degeneracy=reaction.degeneracy, estimator = "rate rules", return_all_kinetics=True)
             if family.own_reverse and hasattr(reaction, 'reverse'):
-                kinetics_list_rev = family.get_kinetics(reaction.reverse, template_labels=reaction.reverse.template, degeneracy=reaction.reverse.degeneracy, return_all_kinetics=True)
+                kinetics_list_rev = family.get_kinetics(reaction.reverse, template_labels=reaction.reverse.template, degeneracy=reaction.reverse.degeneracy, estimator = "rate rules",
+                                                                                        return_all_kinetics=True)
                 for kinetics, source, entry, is_forward in kinetics_list_rev:
                     for kinetics0, source0, entry0, is_forward0 in kinetics_list:
                         if (source0 is not None) and (source is not None) and (entry0 is entry) and (is_forward != is_forward0):


### PR DESCRIPTION
### Issue
See https://github.com/ReactionMechanismGenerator/RMG-Py/issues/2605. Group additivity methods for kinetics were removed from RMG-Py.  As a result, many kinetic searches using RMG website fail with ValueError.

It is not clear whether these will return, and I expect there will probably be some discussion about this - but that might take some time. This PR is a temporary (and possibly permanent, if we decide to just permanently retire group additivity methods) workaround that removes any mentions to kinetic group additivity methods from the RMG-website codebase.

### How to replicate
See difference between kinetic searches 
*RMG-dev*: https://rmg.mit.edu:888/database/kinetics/reaction/reactant1=1%20C%20u0%20p0%20c0%20%7B2,S%7D%20%7B3,S%7D%20%7B4,S%7D%20%7B5,S%7D%0A2%20H%20u0%20p0%20c0%20%7B1,S%7D%0A3%20H%20u0%20p0%20c0%20%7B1,S%7D%0A4%20H%20u0%20p0%20c0%20%7B1,S%7D%0A5%20H%20u0%20p0%20c0%20%7B1,S%7D%0A__reactant2=multiplicity%203%0A1%20O%20u1%20p2%20c0%20%7B2,S%7D%0A2%20O%20u1%20p2%20c0%20%7B1,S%7D%0A__product1=multiplicity%202%0A1%20C%20u1%20p0%20c0%20%7B2,S%7D%20%7B3,S%7D%20%7B4,S%7D%0A2%20H%20u0%20p0%20c0%20%7B1,S%7D%0A3%20H%20u0%20p0%20c0%20%7B1,S%7D%0A4%20H%20u0%20p0%20c0%20%7B1,S%7D%0A__product2=multiplicity%202%0A1%20O%20u0%20p2%20c0%20%7B2,S%7D%20%7B3,S%7D%0A2%20O%20u1%20p2%20c0%20%7B1,S%7D%0A3%20H%20u0%20p0%20c0%20%7B1,S%7D%0A__res=True
*RMG main*: https://rmg.mit.edu/database/kinetics/results/reactant1=1%20C%20u0%20p0%20c0%20%7B2,S%7D%20%7B3,S%7D%20%7B4,S%7D%20%7B5,S%7D%0D%0A2%20H%20u0%20p0%20c0%20%7B1,S%7D%0D%0A3%20H%20u0%20p0%20c0%20%7B1,S%7D%0D%0A4%20H%20u0%20p0%20c0%20%7B1,S%7D%0D%0A5%20H%20u0%20p0%20c0%20%7B1,S%7D__reactant2=multiplicity%203%0D%0A1%20O%20u1%20p2%20c0%20%7B2,S%7D%0D%0A2%20O%20u1%20p2%20c0%20%7B1,S%7D__res=True