### PR TITLE
Temporary fixes to website crash issues

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,14 +3,13 @@
 
 name: rmg_env
 channels:
-  - conda-forge
   - rmg
+  - conda-forge
+  - cantera
   - fhvermei
 dependencies:
-  - beautifulsoup4
   - docutils
   - django =2.2
-  - libgcc
   - lxml
   - pip
   - pip:

--- a/rmgweb/database/tools.py
+++ b/rmgweb/database/tools.py
@@ -47,6 +47,7 @@ from rmgpy.data.rmg import RMGDatabase, SolvationDatabase, StatmechDatabase
 from rmgpy.data.thermo import ThermoDatabase
 from rmgpy.data.transport import TransportDatabase
 from rmgpy.kinetics import Arrhenius
+from rmgpy.kinetics.model import KineticsModel
 from rmgpy.molecule.molecule import Molecule
 from rmgpy.species import Species
 from rmgpy.reaction import same_species_lists
@@ -401,7 +402,9 @@ def generateReactions(database, reactants, products=None, only_families=None, re
         # If the reaction already has kinetics (e.g. from a library),
         # assume the kinetics are satisfactory
         if reaction.kinetics is not None:
-            reaction_data_list.append(reaction)
+            if not isinstance(reaction.kinetics, KineticsModel): # 3/31/25: Added as a temporary stopgap to prevent solvent TS data from crashing.
+                # TODO: eliminate this and add in ability to visualize solvent parameter kinetics.
+                reaction_data_list.append(reaction)
         else:
             # Set the reaction kinetics
             # Only reactions from families should be missing kinetics

--- a/rmgweb/main/views.py
+++ b/rmgweb/main/views.py
@@ -359,24 +359,25 @@ def drawGroup(request, adjlist, format='png'):
 
     adjlist = urllib.parse.unquote(adjlist)
 
-    try:
-        group = Group().from_adjacency_list(adjlist)
-    except (InvalidAdjacencyListError, ValueError):
-        response = HttpResponseRedirect(static('img/invalid_icon.png'))
-    else:
-        if format == 'png':
-            response = HttpResponse(content_type="image/png")
-            response.write(group.draw('png'))
-        elif format == 'svg':
-            response = HttpResponse(content_type="image/svg+xml")
-            svg_data = group.draw('svg')
-            # Remove the scale and rotate transformations applied by pydot
-            svg_data = re.sub(r'scale\(0\.722222 0\.722222\) rotate\(0\) ', '', svg_data)
-            response.write(svg_data)
-        else:
-            response = HttpResponse('Image format not implemented.', status=501)
+    # try:
+    #     group = Group().from_adjacency_list(adjlist)
+    # except (InvalidAdjacencyListError, ValueError):
+    #     response = HttpResponseRedirect(static('img/invalid_icon.png'))
+    # else:
+    #     if format == 'png':
+    #         response = HttpResponse(content_type="image/png")
+    #         response.write(group.draw('png'))
+    #     elif format == 'svg':
+    #         response = HttpResponse(content_type="image/svg+xml")
+    #         svg_data = group.draw('svg')
+    #         # Remove the scale and rotate transformations applied by pydot
+    #         svg_data = re.sub(r'scale\(0\.722222 0\.722222\) rotate\(0\) ', '', svg_data)
+    #         response.write(svg_data)
+    #     else:
+    #         response = HttpResponse('Image format not implemented.', status=501)
 
-    return response
+    # return response
+    return HttpResponse(content_type="image/png") # TODO: fix root cause. Added 3/31/25 as a stopgap to prevent 'neato not found' errors.
 
 
 @login_required


### PR DESCRIPTION
This PR:
* removes groups from drawing graphs due to an unexplained path issue with `neato`, possibly due to package versions.
* prevents `KineticsModel` data (namely, from recently added Chung TS parameters) from showing up in kinetics search, which also yields crashes for a large variety of species.