### PR TITLE
HOTFIX: fix Reaction Libraries from being omitted from kinetics search

### DIFF
--- a/rmgweb/database/tools.py
+++ b/rmgweb/database/tools.py
@@ -402,7 +402,7 @@ def generateReactions(database, reactants, products=None, only_families=None, re
         # If the reaction already has kinetics (e.g. from a library),
         # assume the kinetics are satisfactory
         if reaction.kinetics is not None:
-            if not isinstance(reaction.kinetics, KineticsModel): # 3/31/25: Added as a temporary stopgap to prevent solvent TS data from crashing.
+            if not reaction.kinetics.__class__ is KineticsModel: # 3/31/25: Added as a temporary stopgap to prevent solvent TS data from crashing.
                 # TODO: eliminate this and add in ability to visualize solvent parameter kinetics.
                 reaction_data_list.append(reaction)
         else:


### PR DESCRIPTION
Addresses #294.

Previous commit (https://github.com/ReactionMechanismGenerator/RMG-website/commit/caed55017e63bfea33e39a8e301f3a16ee00dcb0) was aimed at removing website crashes which occurred due library-sourced data with `KineticsModel` kinetics, which do not have any reaction data and therefore cause a crash. 

That removed from search _any_ kinetics which were instances of `KineticsModel`. However, this had the unintended effect of also removing data that are instances of subclasses of `KineticsModel` which _are_ valid and should be included in the kinetics search.

This PR just changes the relevant change to check for class equivalence and not just `isinstance()` which also checks for subclass.

(Tested locally; this restores the kinetics search.)