### PR TITLE
decode bytes for svg

### DIFF
--- a/rmgweb/main/views.py
+++ b/rmgweb/main/views.py
@@ -376,7 +376,7 @@ def drawGroup(request, adjlist, format='png'):
             response.write(group.draw('png'))
         elif format == 'svg':
             response = HttpResponse(content_type="image/svg+xml")
-            svg_data = group.draw('svg')
+            svg_data = group.draw('svg').decode('utf-8')
             # Remove the scale and rotate transformations applied by pydot
             svg_data = re.sub(r'scale\(0\.722222 0\.722222\) rotate\(0\) ', '', svg_data)
             response.write(svg_data)
@@ -384,7 +384,6 @@ def drawGroup(request, adjlist, format='png'):
             response = HttpResponse('Image format not implemented.', status=501)
 
     return response
-#    return HttpResponse(content_type="image/svg+xml")
 
 
 @login_required


### PR DESCRIPTION
rmg website seems to be using Python 2 syntax, where bytes were automatically decoded to strings. When drawing a group, the svg data is returned as bytes, and in python 3 the data needs to be explicitly decoded to a string.

Original error message:
```
Traceback (most recent call last):
  File ".../rmgweb/main/views.py", line 381, in drawGroup
    svg_data = re.sub(r'scale\(0\.722222 0\.722222\) rotate\(0\) ', '', svg_data)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../re/__init__.py", line 185, in sub
    return _compile(pattern, flags).sub(repl, string, count)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Exception Type: TypeError at /group/1 *1 N u0 p1 c0 {2,S} {5,S} {6,S}
2 *2 N u0 p1 c0 {1,S} {3,S} {4,S}
3 *3 N u0 p1 c0 {2,S}
4 *4 H u0 p0 c0 {2,S}
5    H u0 p0 c0 {1,S}
6    H u0 p0 c0 {1,S}
/svg
Exception Value: cannot use a string pattern on a bytes-like object 
```

There might be other instances of this svg bytes not being decoded error in the code, but from the error logs it looks like the error is only raised in main/views.py.