### PR TITLE
Fix profile editing form field ordering

### DIFF
--- a/rmgweb/main/forms.py
+++ b/rmgweb/main/forms.py
@@ -133,7 +133,7 @@ class PasswordChangeForm(PasswordCreateForm):
 
     def __init__(self, *args, **kwargs):
         super(PasswordChangeForm, self).__init__(*args, **kwargs)
-        self.fields.keyOrder = ['current_password', 'password', 'confirm_password']
+        self.order_fields(['current_password', 'password', 'confirm_password'])
         self.fields['password'].label = mark_safe('New&nbsp;password')
         self.fields['confirm_password'].label = mark_safe('Confirm&nbsp;new&nbsp;password')
         self.fields['password'].required = False


### PR DESCRIPTION
When attempting to 'Edit Profile' once logged in, received an error:

`AttributeError: 'dict' object has no attribute 'keyOrder'`

It appears this occurred when it's constructing the password change form.

So, replaced `self.fields.keyOrder` with Django's `order_fields()` method, preserving the current passowrd -> new password -> confirmation order.

